### PR TITLE
feat: input, textarea 컴포넌트 UI 작성

### DIFF
--- a/src/app/components/commons/input/Input.tsx
+++ b/src/app/components/commons/input/Input.tsx
@@ -35,4 +35,6 @@ const Input = forwardRef<HTMLInputElement, Props>(
   },
 );
 
+Input.displayName = 'Input';
+
 export default Input;

--- a/src/app/components/commons/input/Input.tsx
+++ b/src/app/components/commons/input/Input.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { forwardRef } from 'react';
+
+const InputStyles = {
+  base: 'w-full items-center gap-4 rounded-lg px-16 py-8 hover:ring-2 hover:ring-var-orange-300 focus:ring-2 focus:ring-var-orange-600',
+  error: 'ring-var-red ring-2', // form 사용시 에러메시지용 레이아웃
+};
+
+/**
+ * Input 컴포넌트의 props 타입 정의
+ * @property {boolean} [hasError=false] - 에러 상태를 나타내는 선택적 prop
+ * @property {string} [className=''] - 추가적인 사용자 정의 클래스 이름
+ */
+interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
+  hasError?: boolean;
+  className?: string;
+}
+
+/**
+ * Input 컴포넌트 정의
+ *
+ * @param {Props} props - Input 컴포넌트에 전달되는 props
+ * @param {Ref<HTMLInputElement>} ref - forwardRef를 사용하여 전달받은 ref
+ */
+const Input = forwardRef<HTMLInputElement, Props>(
+  ({ hasError = false, className = '', ...rest }, ref) => {
+    return (
+      <input
+        ref={ref}
+        className={`${InputStyles.base} ${hasError && InputStyles.error} ${className}`}
+        {...rest}
+      />
+    );
+  },
+);
+
+export default Input;

--- a/src/app/components/commons/input/Input.tsx
+++ b/src/app/components/commons/input/Input.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { forwardRef } from 'react';
 
-const InputStyles = {
+// @todo: 추후 파일 분리예정
+export const InputStyles = {
   base: 'w-full items-center gap-4 rounded-lg px-16 py-8 hover:ring-2 hover:ring-var-orange-300 focus:ring-2 focus:ring-var-orange-600',
   error: 'ring-var-red ring-2', // form 사용시 에러메시지용 레이아웃
 };

--- a/src/app/components/commons/input/Input.tsx
+++ b/src/app/components/commons/input/Input.tsx
@@ -14,7 +14,7 @@ export const InputStyles = {
  * @property {boolean} [hasError=false] - 에러 상태를 나타내는 선택적 prop
  * @property {string} [className=''] - 추가적인 사용자 정의 클래스 이름
  */
-interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   hasError?: boolean;
   className?: string;
 }
@@ -25,7 +25,7 @@ interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
  * @param {InputProps} props - Input 컴포넌트에 전달되는 props
  * @param {Ref<HTMLInputElement>} ref - forwardRef를 사용하여 전달받은 ref
  */
-const Input = forwardRef<HTMLInputElement, Props>(
+const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ hasError = false, className = '', ...rest }, ref) => {
     return (
       <input

--- a/src/app/components/commons/input/Input.tsx
+++ b/src/app/components/commons/input/Input.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { forwardRef } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 
 // @todo: 추후 파일 분리예정
 export const InputStyles = {
@@ -9,7 +9,7 @@ export const InputStyles = {
   error: 'ring-var-red ring-2', // form 사용시 에러메시지용 레이아웃
 };
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   hasError?: boolean;
   className?: string;
 }
@@ -22,8 +22,8 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
  *
  * @param {boolean} [hasError=false] - 에러 상태를 나타내는 선택적 prop
  * @param {string} [className=''] - 추가적인 사용자 정의 클래스 이름
- * @param {React.InputHTMLAttributes<HTMLInputElement>} rest - Input 요소의 모든 속성을 Props로 받아 사용할 수 있습니다.
- * @param {React.Ref<HTMLInputElement>} ref - forwardRef를 사용하여 전달받은 ref
+ * @param {InputHTMLAttributes<HTMLInputElement>} rest - Input 요소의 모든 속성을 Props로 받아 사용할 수 있습니다.
+ * @param {Ref<HTMLInputElement>} ref - forwardRef를 사용하여 전달받은 ref
  */
 const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ hasError = false, className = '', ...rest }, ref) => {

--- a/src/app/components/commons/input/Input.tsx
+++ b/src/app/components/commons/input/Input.tsx
@@ -3,7 +3,9 @@ import { forwardRef } from 'react';
 
 // @todo: 추후 파일 분리예정
 export const InputStyles = {
-  base: 'w-full items-center gap-4 rounded-lg px-16 py-8 hover:ring-2 hover:ring-var-orange-300 focus:ring-2 focus:ring-var-orange-600',
+  base: 'w-full items-center gap-4 rounded-lg px-16 py-8 focus:ring-2',
+  hover: 'hover:ring-2 hover:ring-var-orange-300',
+  focus: 'focus:ring-var-orange-600',
   error: 'ring-var-red ring-2', // form 사용시 에러메시지용 레이아웃
 };
 
@@ -20,7 +22,7 @@ interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
 /**
  * Input 컴포넌트 정의
  *
- * @param {Props} props - Input 컴포넌트에 전달되는 props
+ * @param {InputProps} props - Input 컴포넌트에 전달되는 props
  * @param {Ref<HTMLInputElement>} ref - forwardRef를 사용하여 전달받은 ref
  */
 const Input = forwardRef<HTMLInputElement, Props>(
@@ -28,7 +30,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
     return (
       <input
         ref={ref}
-        className={`${InputStyles.base} ${hasError && InputStyles.error} ${className}`}
+        className={`${InputStyles.base} hover: ${InputStyles.hover} focus: ${InputStyles.focus} ${hasError && InputStyles.error} ${className}`}
         {...rest}
       />
     );

--- a/src/app/components/commons/input/Input.tsx
+++ b/src/app/components/commons/input/Input.tsx
@@ -9,11 +9,6 @@ export const InputStyles = {
   error: 'ring-var-red ring-2', // form 사용시 에러메시지용 레이아웃
 };
 
-/**
- * Input 컴포넌트의 props 타입 정의
- * @property {boolean} [hasError=false] - 에러 상태를 나타내는 선택적 prop
- * @property {string} [className=''] - 추가적인 사용자 정의 클래스 이름
- */
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   hasError?: boolean;
   className?: string;
@@ -22,8 +17,13 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 /**
  * Input 컴포넌트 정의
  *
- * @param {InputProps} props - Input 컴포넌트에 전달되는 props
- * @param {Ref<HTMLInputElement>} ref - forwardRef를 사용하여 전달받은 ref
+ * 기본적으로 사용하는 Input 컴포넌트입니다.
+ * 하위의 Props를 사용하여 Input의 모든 요소에 접근하여 사용하실 수 있습니다.
+ *
+ * @param {boolean} [hasError=false] - 에러 상태를 나타내는 선택적 prop
+ * @param {string} [className=''] - 추가적인 사용자 정의 클래스 이름
+ * @param {React.InputHTMLAttributes<HTMLInputElement>} rest - Input 요소의 모든 속성을 Props로 받아 사용할 수 있습니다.
+ * @param {React.Ref<HTMLInputElement>} ref - forwardRef를 사용하여 전달받은 ref
  */
 const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ hasError = false, className = '', ...rest }, ref) => {

--- a/src/app/components/commons/input/InputText.tsx
+++ b/src/app/components/commons/input/InputText.tsx
@@ -22,7 +22,7 @@ const InputText = ({ value, placeholder = '', onChange }: InputTextProps) => {
       value={value}
       placeholder={placeholder}
       onChange={onChange}
-      spellcheck='false'
+      spellCheck={false}
     />
   );
 };

--- a/src/app/components/commons/input/InputText.tsx
+++ b/src/app/components/commons/input/InputText.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { InputStyles } from './Input';
+
+interface Props {
+  value: string;
+  placeholder?: string;
+  onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+/**
+ * InputText 컴포넌트는 사용자가 입력할 수 있는 텍스트 영역을 제공합니다.
+ * @param {Props} props - 컴포넌트의 속성
+ * @param {string} props.value - 텍스트 영역의 값
+ * @param {string} [props.placeholder] - 텍스트 영역의 플레이스홀더 텍스트
+ * @param {function} props.onChange - 텍스트 영역 값이 변경될 때 호출되는 함수
+ */
+export default function InputText({ value, placeholder, onChange }: Props) {
+  return (
+    <textarea
+      className={`${InputStyles.base} h-full resize-none overflow-auto outline-none`}
+      value={value}
+      placeholder={placeholder}
+      onChange={onChange}
+    />
+  );
+}

--- a/src/app/components/commons/input/InputText.tsx
+++ b/src/app/components/commons/input/InputText.tsx
@@ -18,7 +18,7 @@ interface InputTextProps {
 const InputText = ({ value, placeholder = '', onChange }: InputTextProps) => {
   return (
     <textarea
-      className={`${InputStyles.base} h-full resize-none overflow-auto`}
+      className={`${InputStyles.base} h-full resize-none overflow-auto focus:outline-var-orange-300`}
       value={value}
       placeholder={placeholder}
       onChange={onChange}

--- a/src/app/components/commons/input/InputText.tsx
+++ b/src/app/components/commons/input/InputText.tsx
@@ -2,7 +2,7 @@
 
 import { InputStyles } from './Input';
 
-interface Props {
+interface InputTextProps {
   value: string;
   placeholder?: string;
   onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
@@ -15,10 +15,14 @@ interface Props {
  * @param {string} [props.placeholder] - 텍스트 영역의 플레이스홀더 텍스트
  * @param {function} props.onChange - 텍스트 영역 값이 변경될 때 호출되는 함수
  */
-export default function InputText({ value, placeholder, onChange }: Props) {
+export default function InputText({
+  value,
+  placeholder,
+  onChange,
+}: InputTextProps) {
   return (
     <textarea
-      className={`${InputStyles.base} h-full resize-none overflow-auto outline-none`}
+      className={`${InputStyles.base} h-full resize-none overflow-auto`}
       value={value}
       placeholder={placeholder}
       onChange={onChange}

--- a/src/app/components/commons/input/InputText.tsx
+++ b/src/app/components/commons/input/InputText.tsx
@@ -22,6 +22,7 @@ const InputText = ({ value, placeholder = '', onChange }: InputTextProps) => {
       value={value}
       placeholder={placeholder}
       onChange={onChange}
+      spellcheck='false'
     />
   );
 };

--- a/src/app/components/commons/input/InputText.tsx
+++ b/src/app/components/commons/input/InputText.tsx
@@ -15,11 +15,7 @@ interface InputTextProps {
  * @param {string} [props.placeholder] - 텍스트 영역의 플레이스홀더 텍스트
  * @param {function} props.onChange - 텍스트 영역 값이 변경될 때 호출되는 함수
  */
-export default function InputText({
-  value,
-  placeholder,
-  onChange,
-}: InputTextProps) {
+const InputText = ({ value, placeholder = '', onChange }: InputTextProps) => {
   return (
     <textarea
       className={`${InputStyles.base} h-full resize-none overflow-auto`}
@@ -28,4 +24,6 @@ export default function InputText({
       onChange={onChange}
     />
   );
-}
+};
+
+export default InputText;

--- a/src/app/components/commons/input/InputText.tsx
+++ b/src/app/components/commons/input/InputText.tsx
@@ -1,11 +1,11 @@
 'use client';
-
+import { ChangeEvent } from 'react';
 import { InputStyles } from './Input';
 
 interface InputTextProps {
   value: string;
   placeholder?: string;
-  onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 /**


### PR DESCRIPTION
## ✏️ 작업 내용

- input UI 작성
- textarea UI 작성

## 📷 스크린샷
<img width="703" alt="스크린샷 2024-09-05 오후 6 41 31" src="https://github.com/user-attachments/assets/6ad4ed92-f937-4dfa-ba53-c22813a7548c"><br>
기본 <br>
<img width="713" alt="스크린샷 2024-09-05 오후 6 41 37" src="https://github.com/user-attachments/assets/974e577f-75c5-4d63-a559-9df2601b747c"><br>
hover <br>
<img width="706" alt="스크린샷 2024-09-05 오후 6 41 43" src="https://github.com/user-attachments/assets/4d6df767-8b41-4fc7-b10a-159d06186e60"><br>
focus<br>
<img width="702" alt="스크린샷 2024-09-05 오후 6 42 19" src="https://github.com/user-attachments/assets/debe9f96-4a75-4382-9298-fad073aadd41"><br>
textarea 스크롤 <br>




## ✍️ 사용법
- 기본적으로 width는 full 맞춰져 있습니다. 부모요소에 width를 주시면 원하는대로 조절 가능합니다
- 기본 input에서 class를 추가하고 싶으시다면 props로 className을 지정해주시면 반영됩니다.
- Input 컴포넌트의 모든 기본 HTML 속성 및 이벤트 핸들러는 props를 통해 전달가능합니다.
-  forwardRef를 사용하여 부모 컴포넌트가 자식 컴포넌트의 ref를 직접 참조할 수 있습니다.
- forwardRef는 부모 컴포넌트가 자식 컴포넌트의 DOM 노드에 직접 접근할 수 있게 해 주며, 이는 특히 폼 요소와 같은 기본 HTML 요소를 래핑하는 컴포넌트에서 유용합니다.
- ref는 input 요소에 대한 참조를 제공하며, 예를 들어 포커스 제어 등에 사용가능합니다.


## 🎸 기타

close #13
