### PR TITLE
feat: 공통 컴포넌트 gnb 컴포넌트 UI 작성

### DIFF
--- a/src/app/components/Gnb/Gnb.tsx
+++ b/src/app/components/Gnb/Gnb.tsx
@@ -2,19 +2,20 @@
 import { Logo } from '@/public/images';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import UserStatus from './UserStatus';
 
 //@todo pathname 정해질 시 추가 예정
 const navList = [
   {
-    text: '모임 찾기',
+    name: '모임 찾기',
     link: '#',
   },
   {
-    text: '찜한 모임',
+    name: '찜한 모임',
     link: '#',
   },
   {
-    text: '모든 리뷰',
+    name: '모든 리뷰',
     link: '#',
   },
 ];
@@ -36,17 +37,14 @@ const Gnb = () => {
                   className={`text-[16px] font-semibold ${pathname.includes(nav.link) ? 'text-black' : 'text-white'}`}
                   href={nav.link}
                 >
-                  {nav.text}
+                  {nav.name}
                 </Link>
               </li>
             ))}
           </ul>
         </nav>
       </div>
-      {/* @todo 임시 경로입니다. */}
-      <Link href='/signin'>
-        <div className='text-[16px] font-semibold text-white'>로그인</div>
-      </Link>
+      <UserStatus />
     </header>
   );
 };

--- a/src/app/components/Gnb/Gnb.tsx
+++ b/src/app/components/Gnb/Gnb.tsx
@@ -25,7 +25,7 @@ const Gnb = () => {
 
   return (
     <header className='gap-0 bg-var-orange-600 py-16'>
-      <div className='mx-16 flex max-w-[1200px] items-center justify-between lg:mx-auto lg:px-24'>
+      <div className='mx-16 flex max-w-[1200px] items-center justify-between md:mx-24 lg:mx-auto'>
         <nav className='flex items-center'>
           <Link href='/'>
             <Logo className='mr-20 h-40 w-72' />

--- a/src/app/components/Gnb/Gnb.tsx
+++ b/src/app/components/Gnb/Gnb.tsx
@@ -1,7 +1,9 @@
+'use client';
 import { Logo } from '@/public/images';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
-//@todo Link 정해질 시 추가 예정
+//@todo pathname 정해질 시 추가 예정
 const navList = [
   {
     text: '모임 찾기',
@@ -18,6 +20,8 @@ const navList = [
 ];
 
 const Gnb = () => {
+  const pathname = usePathname();
+
   return (
     <header className='flex items-center justify-between gap-0 bg-var-orange-600 py-16'>
       <div className='flex items-center'>
@@ -27,14 +31,22 @@ const Gnb = () => {
         <nav className='flex'>
           <ul className='flex gap-24'>
             {navList.map((nav, index) => (
-              <li className='text-[16px] font-semibold text-white' key={index}>
-                <Link href={nav.link}>{nav.text}</Link>
+              <li key={index}>
+                <Link
+                  className={`text-[16px] font-semibold ${pathname.includes(nav.link) ? 'text-black' : 'text-white'}`}
+                  href={nav.link}
+                >
+                  {nav.text}
+                </Link>
               </li>
             ))}
           </ul>
         </nav>
       </div>
-      <div className='text-[16px] font-semibold text-white'>로그인</div>
+      {/* @todo 임시 경로입니다. */}
+      <Link href='/signin'>
+        <div className='text-[16px] font-semibold text-white'>로그인</div>
+      </Link>
     </header>
   );
 };

--- a/src/app/components/Gnb/Gnb.tsx
+++ b/src/app/components/Gnb/Gnb.tsx
@@ -1,0 +1,42 @@
+import { Logo } from '@/public/images';
+import Link from 'next/link';
+
+//@todo Link 정해질 시 추가 예정
+const navList = [
+  {
+    text: '모임 찾기',
+    link: '#',
+  },
+  {
+    text: '찜한 모임',
+    link: '#',
+  },
+  {
+    text: '모든 리뷰',
+    link: '#',
+  },
+];
+
+const Gnb = () => {
+  return (
+    <header className='flex items-center justify-between gap-0 bg-var-orange-600 py-16'>
+      <div className='flex items-center'>
+        <Link href='/'>
+          <Logo className='mr-20 h-40 w-72' />
+        </Link>
+        <nav className='flex'>
+          <ul className='flex gap-24'>
+            {navList.map((nav, index) => (
+              <li className='text-[16px] font-semibold text-white' key={index}>
+                <Link href={nav.link}>{nav.text}</Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
+      <div className='text-[16px] font-semibold text-white'>로그인</div>
+    </header>
+  );
+};
+
+export default Gnb;

--- a/src/app/components/Gnb/Gnb.tsx
+++ b/src/app/components/Gnb/Gnb.tsx
@@ -24,12 +24,12 @@ const Gnb = () => {
   const pathname = usePathname();
 
   return (
-    <header className='flex items-center justify-between gap-0 bg-var-orange-600 py-16'>
-      <div className='flex items-center'>
-        <Link href='/'>
-          <Logo className='mr-20 h-40 w-72' />
-        </Link>
-        <nav className='flex'>
+    <header className='gap-0 bg-var-orange-600 py-16'>
+      <div className='mx-16 flex max-w-[1200px] items-center justify-between lg:mx-auto lg:px-24'>
+        <nav className='flex items-center'>
+          <Link href='/'>
+            <Logo className='mr-20 h-40 w-72' />
+          </Link>
           <ul className='flex gap-24'>
             {navList.map((nav, index) => (
               <li key={index}>
@@ -43,8 +43,8 @@ const Gnb = () => {
             ))}
           </ul>
         </nav>
+        <UserStatus />
       </div>
-      <UserStatus />
     </header>
   );
 };

--- a/src/app/components/Gnb/UserStatus.tsx
+++ b/src/app/components/Gnb/UserStatus.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Profile } from '@/public/images';
+import Link from 'next/link';
+import { useState, useRef, useEffect } from 'react';
+
+/* user을 null로 설정하면 로그아웃된 상황을 볼 수 있습니다. */
+const user = {
+  name: 'test name',
+};
+
+const options = [{ name: '마이페이지' }, { name: '로그아웃' }];
+
+const UserStatus = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const dropDownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropDownRef.current &&
+        !dropDownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <>
+      {user ? (
+        <div className='relative' ref={dropDownRef}>
+          <Profile
+            className='size-40'
+            onClick={() => setIsOpen((prev) => !prev)}
+          />
+          {isOpen && (
+            <ul className='absolute right-0 mt-8 max-h-240 w-120 overflow-y-auto rounded-xl bg-var-gray-50 lg:left-0'>
+              {options.map((option, index) => (
+                <li
+                  key={index}
+                  className='cursor-pointer px-16 py-12 text-[12px] font-medium text-var-black hover:bg-var-orange-100 md:px-16'
+                >
+                  {option.name}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : (
+        <Link href='/signin'>
+          {/* @todo 임시 경로입니다. */}
+          <div className='text-[16px] font-semibold text-white'>로그인</div>
+        </Link>
+      )}
+    </>
+  );
+};
+
+export default UserStatus;


### PR DESCRIPTION
## ✏️ 작업 내용

- gnb 컴포넌트 UI 작성

## 📷 스크린샷
<img width="1440" alt="스크린샷 2024-09-06 오후 4 16 39" src="https://github.com/user-attachments/assets/fe36787b-b6f2-46a9-b171-085dba671dd5"><br>
PC사이즈<br>
<img width="853" alt="스크린샷 2024-09-06 오후 4 22 17" src="https://github.com/user-attachments/assets/566f1468-2bc1-4bdb-9304-b92e36969f1e"><br>
태블릿사이즈<br>
<img width="431" alt="스크린샷 2024-09-06 오후 4 21 45" src="https://github.com/user-attachments/assets/6ce511e2-0bbb-473d-873c-189af85c507b"><br>
모바일사이즈<br>
<img width="827" alt="스크린샷 2024-09-06 오후 4 24 46" src="https://github.com/user-attachments/assets/665dd99f-cc6c-4f82-bac8-6ef5a634b286"><br>
로그아웃상태 레이아웃<br>
<img width="274" alt="스크린샷 2024-09-06 오후 4 23 48" src="https://github.com/user-attachments/assets/4bf666e5-3c93-4c32-9648-a091cb209ccd"><br>
모임찾기 활성화시(예시)<br>
<img width="155" alt="스크린샷 2024-09-06 오후 4 25 41" src="https://github.com/user-attachments/assets/eb9611ec-9fec-4490-ac85-daebd6acd133"><br>
프로필 드롭다운<br>



## ✍️ 사용법
```js
//UserStatus.tsx
const user = {
  name: 'test name',
}; // 이부분을 null로 바꿔 로그아웃시 레이아웃을 볼 수 있습니다.
```

## 🎸 기타

- 현재 pathname이 지정되지 않아 네비게이션바의 링크는 '#'로 되어있습니다. 정해지면 수정 예정입니다.
- 