### PR TITLE
fix: 우측 텍스트 조건부 렌더링 옵션 추가

### DIFF
--- a/src/app/components/ProgressBar/ProgressBar.tsx
+++ b/src/app/components/ProgressBar/ProgressBar.tsx
@@ -8,6 +8,7 @@ import { IconArrow, IconCheckCircle, IconPerson } from '@/public/icons';
  * @param {number} participantNumber - 참여 인원 수
  * @param {boolean} hasParticipantNumber - 참여 인원 수 렌더링 여부
  * @param {boolean} hasOpeningConfirmed - 개설 확정 렌더링 여부
+ * @param {boolean} hasText - 우측 텍스트 (join now 혹은 Closed) 렌더링 여부
  */
 
 interface ProgressBarProps {
@@ -15,6 +16,7 @@ interface ProgressBarProps {
   capacity: number;
   hasParticipantNumber: boolean;
   hasOpeningConfirmed: boolean;
+  hasText: boolean;
 }
 
 const ProgressBar = ({
@@ -22,6 +24,7 @@ const ProgressBar = ({
   capacity,
   hasParticipantNumber,
   hasOpeningConfirmed,
+  hasText,
 }: ProgressBarProps) => {
   const isOpeningConfirmed = participantNumber >= 5; // 개설 확정 여부 (boolean)
   const isClosedGathering = participantNumber === capacity; // 참여 인원이 다 찬 경우 (boolean)
@@ -58,11 +61,15 @@ const ProgressBar = ({
       </div>
       {/* user action */}
       {isClosedGathering ? (
-        <div className='text-16 flex items-center font-semibold text-var-orange-400'>
+        <div
+          className={`${hasText ? 'block' : 'hidden'} text-16 flex items-center font-semibold text-var-orange-400`}
+        >
           Closed
         </div>
       ) : (
-        <div className='text-16 flex items-center gap-8 whitespace-nowrap font-semibold text-var-orange-600'>
+        <div
+          className={`${hasText ? 'block' : 'hidden'} text-16 flex items-center gap-8 whitespace-nowrap font-semibold text-var-orange-600`}
+        >
           join now
           <IconArrow className='h-[18px] w-[18px]' />
         </div>


### PR DESCRIPTION
## ✏️ 작업 내용

- 우측 텍스트에 따른 조건부 렌더링 옵션을 만들었습니다.

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/43695067-30c0-4c33-a37a-23748c846c73)


## ✍️ 사용법
```js
// 우측 텍스트 없는 버전 (1)
<ProgressBar
  participantNumber={5}
  hasParticipantNumber={true}
  hasOpeningConfirmed={true}
  capacity={20}
  hasText={false}
/>
// 우측 텍스트 없는 버전 (2)
<ProgressBar
  participantNumber={20}
  hasParticipantNumber={true}
  hasOpeningConfirmed={true}
  capacity={20}
  hasText={false}
/>
```
## 🎸 기타
[참고할 PR](https://github.com/INtiful/SootheWithMe/pull/30)
새로 반영한 내용의 예시도 위 PR에 반영하도록 수정하였습니다.
