### PR TITLE
feat: Bottom Floating Bar 컴포넌트 UI 작성

### DIFF
--- a/src/app/components/BottomFloatingBar/BottomFloatingBar.tsx
+++ b/src/app/components/BottomFloatingBar/BottomFloatingBar.tsx
@@ -3,8 +3,32 @@
 import ParticipationButton from './ParticipationButton';
 import { userData, groupData, participantsData } from './Mock';
 
-const BottomFloatingBar = () => {
-  const isHost = groupData.createdBy === userData.id; //주최자인지 검사
+interface Participant {
+  User: {
+    id: number;
+  };
+}
+
+interface ParticipationButtonProps {
+  user: { name: string; id: number };
+  createdBy: number;
+  participantCount: number;
+  capacity: number;
+  registrationEnd: Date;
+  canceledAt: null | Date;
+  participantsData: Participant[];
+}
+
+const BottomFloatingBar = ({
+  user,
+  createdBy,
+  participantCount,
+  capacity,
+  registrationEnd,
+  canceledAt,
+  participantsData,
+}: ParticipationButtonProps) => {
+  const isHost = createdBy === userData.id; //주최자인지 검사
 
   return (
     <section className='fixed bottom-0 w-full border-t-2 border-var-black bg-var-white px-16 py-20 md:px-24'>
@@ -22,11 +46,11 @@ const BottomFloatingBar = () => {
         </div>
         <ParticipationButton
           isHost={isHost}
-          user={userData}
-          participantCount={groupData.participantCount}
-          capacity={groupData.capacity}
-          registrationEnd={groupData.registrationEnd}
-          canceledAt={groupData.canceledAt}
+          user={user}
+          participantCount={participantCount}
+          capacity={capacity}
+          registrationEnd={registrationEnd}
+          canceledAt={canceledAt}
           participantsData={participantsData}
         />
       </div>

--- a/src/app/components/BottomFloatingBar/BottomFloatingBar.tsx
+++ b/src/app/components/BottomFloatingBar/BottomFloatingBar.tsx
@@ -1,8 +1,11 @@
-import Button from '../Button/Button';
+'use client';
+
+import ParticipationButton from './ParticipationButton';
+import { userData, groupData, participantsData } from './Mock';
 
 const BottomFloatingBar = () => {
   return (
-    <section className='border-t-2 border-var-black bg-var-white px-16 py-20 md:px-24'>
+    <section className='fixed bottom-0 w-full border-t-2 border-var-black bg-var-white px-16 py-20 md:px-24'>
       <div className='flex max-w-[996px] justify-between lg:mx-auto'>
         <div>
           <h2 className='text-14 font-semibold lg:text-16'>
@@ -13,9 +16,15 @@ const BottomFloatingBar = () => {
             회복해봐요
           </p>
         </div>
-        <div className='w-[115px]'>
-          <Button name='참여하기' variant='default' type='button' />
-        </div>
+        <ParticipationButton
+          user={userData}
+          createdBy={groupData.createdBy}
+          participantCount={groupData.participantCount}
+          capacity={groupData.capacity}
+          registrationEnd={groupData.registrationEnd}
+          canceledAt={groupData.canceledAt}
+          participantsData={participantsData}
+        />
       </div>
     </section>
   );

--- a/src/app/components/BottomFloatingBar/BottomFloatingBar.tsx
+++ b/src/app/components/BottomFloatingBar/BottomFloatingBar.tsx
@@ -9,13 +9,13 @@ interface Participant {
   };
 }
 
-interface ParticipationButtonProps {
+interface BottomFloatingBarProps {
   user: { name: string; id: number };
   createdBy: number;
   participantCount: number;
   capacity: number;
-  registrationEnd: Date;
-  canceledAt: null | Date;
+  registrationEnd: string;
+  canceledAt: null | string;
   participantsData: Participant[];
 }
 
@@ -27,7 +27,7 @@ const BottomFloatingBar = ({
   registrationEnd,
   canceledAt,
   participantsData,
-}: ParticipationButtonProps) => {
+}: BottomFloatingBarProps) => {
   const isHost = createdBy === userData.id; //주최자인지 검사
 
   return (

--- a/src/app/components/BottomFloatingBar/BottomFloatingBar.tsx
+++ b/src/app/components/BottomFloatingBar/BottomFloatingBar.tsx
@@ -4,9 +4,13 @@ import ParticipationButton from './ParticipationButton';
 import { userData, groupData, participantsData } from './Mock';
 
 const BottomFloatingBar = () => {
+  const isHost = groupData.createdBy === userData.id; //주최자인지 검사
+
   return (
     <section className='fixed bottom-0 w-full border-t-2 border-var-black bg-var-white px-16 py-20 md:px-24'>
-      <div className='flex max-w-[996px] justify-between lg:mx-auto'>
+      <div
+        className={`flex max-w-[996px] justify-between lg:mx-auto ${isHost && 'flex-col items-center gap-[10px] md:flex-row'}`}
+      >
         <div>
           <h2 className='text-14 font-semibold lg:text-16'>
             더 건강한 나와 팀을 위한 프로그램 🏃‍️️
@@ -17,8 +21,8 @@ const BottomFloatingBar = () => {
           </p>
         </div>
         <ParticipationButton
+          isHost={isHost}
           user={userData}
-          createdBy={groupData.createdBy}
           participantCount={groupData.participantCount}
           capacity={groupData.capacity}
           registrationEnd={groupData.registrationEnd}

--- a/src/app/components/BottomFloatingBar/BottomFloatingBar.tsx
+++ b/src/app/components/BottomFloatingBar/BottomFloatingBar.tsx
@@ -1,0 +1,24 @@
+import Button from '../Button/Button';
+
+const BottomFloatingBar = () => {
+  return (
+    <section className='border-t-2 border-var-black bg-var-white px-16 py-20 md:px-24'>
+      <div className='flex max-w-[996px] justify-between lg:mx-auto'>
+        <div>
+          <h2 className='text-14 font-semibold lg:text-16'>
+            더 건강한 나와 팀을 위한 프로그램 🏃‍️️
+          </h2>
+          <p className='text-12 font-medium'>
+            국내 최고 웰니스 전문가와 프로그램을 통해 지친 몸과 마음을
+            회복해봐요
+          </p>
+        </div>
+        <div className='w-[115px]'>
+          <Button name='참여하기' variant='default' type='button' />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BottomFloatingBar;

--- a/src/app/components/BottomFloatingBar/Mock.ts
+++ b/src/app/components/BottomFloatingBar/Mock.ts
@@ -7,17 +7,18 @@ export const userData = {
 /* 모임 상세 조회 mock data */
 export const groupData = {
   id: 0,
-  registrationEnd: '2024-09-15T23:59:59Z',
+  registrationEnd: new Date('2024-09-02T23:59:59Z'),
   participantCount: 5,
   capacity: 10,
-  createdBy: 1234,
+  createdBy: 1224,
   canceledAt: null,
 };
 
+/* 참가자 mock data */
 export const participantsData = [
   {
     User: {
-      id: 1234,
+      id: 1232,
     },
   },
   {
@@ -41,3 +42,9 @@ export const participantsData = [
     },
   },
 ];
+
+/* 예비로 추가한 이벤트핸들링함수 */
+export const onCancel = () => console.log('모임이 취소되었습니다.');
+export const onShare = () => console.log('모임을 공유했습니다.');
+export const onJoin = () => console.log('모임에 참여했습니다.');
+export const onWithdraw = () => console.log('참여를 취소했습니다.');

--- a/src/app/components/BottomFloatingBar/Mock.ts
+++ b/src/app/components/BottomFloatingBar/Mock.ts
@@ -7,10 +7,10 @@ export const userData = {
 /* 모임 상세 조회 mock data */
 export const groupData = {
   id: 0,
-  registrationEnd: new Date('2024-09-02T23:59:59Z'),
+  registrationEnd: '2024-09-22T23:59:59Z',
   participantCount: 5,
   capacity: 10,
-  createdBy: 1224,
+  createdBy: 1232,
   canceledAt: null,
 };
 

--- a/src/app/components/BottomFloatingBar/Mock.ts
+++ b/src/app/components/BottomFloatingBar/Mock.ts
@@ -1,0 +1,43 @@
+/* user mock data */
+export const userData = {
+  name: 'test name',
+  id: 1234,
+};
+
+/* 모임 상세 조회 mock data */
+export const groupData = {
+  id: 0,
+  registrationEnd: '2024-09-15T23:59:59Z',
+  participantCount: 5,
+  capacity: 10,
+  createdBy: 1234,
+  canceledAt: null,
+};
+
+export const participantsData = [
+  {
+    User: {
+      id: 1234,
+    },
+  },
+  {
+    User: {
+      id: 1534,
+    },
+  },
+  {
+    User: {
+      id: 1344,
+    },
+  },
+  {
+    User: {
+      id: 1654,
+    },
+  },
+  {
+    User: {
+      id: 1634,
+    },
+  },
+];

--- a/src/app/components/BottomFloatingBar/ParticipationButton.tsx
+++ b/src/app/components/BottomFloatingBar/ParticipationButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Button from '../Button/Button';
 //@todo 함수 기능 구현
 import { onCancel, onShare, onJoin, onWithdraw } from './Mock';
@@ -10,8 +12,8 @@ interface Participant {
 
 // @todo api 연결 후 Props 수정
 interface ParticipationButtonProps {
+  isHost: boolean;
   user: { name: string; id: number };
-  createdBy: number;
   participantCount: number;
   capacity: number;
   registrationEnd: Date;
@@ -21,14 +23,13 @@ interface ParticipationButtonProps {
 
 const ParticipationButton = ({
   user,
-  createdBy,
+  isHost,
   participantCount,
   capacity,
   registrationEnd,
   canceledAt,
   participantsData,
 }: ParticipationButtonProps) => {
-  const isHost = createdBy === user.id; //주최자인지 검사
   const isFull = participantCount === capacity; //참여인원이 가득찼는지 검사
   const isRegistrationEnded = new Date() > new Date(registrationEnd); // 마감일이 지났는지 검사
   const hasParticipated = participantsData.some(
@@ -43,7 +44,7 @@ const ParticipationButton = ({
     onClick?: () => void,
     disabled = false,
   ) => (
-    <div className='h-44 w-[115px]'>
+    <div className={`h-44 w-[115px] ${isHost && 'w-full md:w-[115px]'}`}>
       <Button
         name={name}
         type='button'
@@ -56,23 +57,23 @@ const ParticipationButton = ({
 
   // 주최자일 경우
   if (isHost) {
+    const disabled = isRegistrationEnded || isCancelled; // 마감일이 지났거나 취소되었을 경우 button 비활성화
     return (
-      <div className='flex gap-[10px]'>
-        {renderButton('취소하기', 'white', onCancel)}
-        {renderButton('공유하기', 'default', onShare)}
+      <div className='flex w-[330px] gap-[10px]'>
+        {renderButton('취소하기', 'white', onCancel, disabled)}
+        {renderButton('공유하기', 'default', onShare, disabled)}
       </div>
     );
   }
 
-  // 참여 불가능한 조건 (정원이 찼거나, 마감일이 지났거나, 취소된 모임)
-  if (isFull || isRegistrationEnded || isCancelled) {
-    return renderButton('참여하기', 'gray', undefined, true);
-  }
+  const isParticipationDisabled = isFull || isRegistrationEnded || isCancelled; // 참여 가능 여부 검사
 
-  // 참여 상태에 따른 버튼 표시
-  return hasParticipated
-    ? renderButton('참여 취소하기', 'white', onWithdraw)
-    : renderButton('참여하기', 'default', onJoin);
+  return renderButton(
+    hasParticipated ? '참여 취소하기' : '참여하기', // 이미 참여했는지 검사
+    hasParticipated ? 'white' : 'default', // button 종류 결정
+    hasParticipated ? onWithdraw : onJoin, // 함수 결정
+    isParticipationDisabled, // disable 여부
+  );
 };
 
 export default ParticipationButton;

--- a/src/app/components/BottomFloatingBar/ParticipationButton.tsx
+++ b/src/app/components/BottomFloatingBar/ParticipationButton.tsx
@@ -1,0 +1,78 @@
+import Button from '../Button/Button';
+//@todo 함수 기능 구현
+import { onCancel, onShare, onJoin, onWithdraw } from './Mock';
+
+interface Participant {
+  User: {
+    id: number;
+  };
+}
+
+// @todo api 연결 후 Props 수정
+interface ParticipationButtonProps {
+  user: { name: string; id: number };
+  createdBy: number;
+  participantCount: number;
+  capacity: number;
+  registrationEnd: Date;
+  canceledAt: null | Date;
+  participantsData: Participant[];
+}
+
+const ParticipationButton = ({
+  user,
+  createdBy,
+  participantCount,
+  capacity,
+  registrationEnd,
+  canceledAt,
+  participantsData,
+}: ParticipationButtonProps) => {
+  const isHost = createdBy === user.id; //주최자인지 검사
+  const isFull = participantCount === capacity; //참여인원이 가득찼는지 검사
+  const isRegistrationEnded = new Date() > new Date(registrationEnd); // 마감일이 지났는지 검사
+  const hasParticipated = participantsData.some(
+    (participant) => participant.User.id === user.id,
+  ); //이미 참여했는지 검사
+  const isCancelled = Boolean(canceledAt); //취소되었는지 검사
+
+  /* 버튼 렌더링 함수 */
+  const renderButton = (
+    name: string,
+    variant: 'white' | 'default' | 'gray',
+    onClick?: () => void,
+    disabled = false,
+  ) => (
+    <div className='h-44 w-[115px]'>
+      <Button
+        name={name}
+        type='button'
+        onClick={onClick}
+        variant={variant}
+        disabled={disabled}
+      />
+    </div>
+  );
+
+  // 주최자일 경우
+  if (isHost) {
+    return (
+      <div className='flex gap-[10px]'>
+        {renderButton('취소하기', 'white', onCancel)}
+        {renderButton('공유하기', 'default', onShare)}
+      </div>
+    );
+  }
+
+  // 참여 불가능한 조건 (정원이 찼거나, 마감일이 지났거나, 취소된 모임)
+  if (isFull || isRegistrationEnded || isCancelled) {
+    return renderButton('참여하기', 'gray', undefined, true);
+  }
+
+  // 참여 상태에 따른 버튼 표시
+  return hasParticipated
+    ? renderButton('참여 취소하기', 'white', onWithdraw)
+    : renderButton('참여하기', 'default', onJoin);
+};
+
+export default ParticipationButton;

--- a/src/app/components/BottomFloatingBar/ParticipationButton.tsx
+++ b/src/app/components/BottomFloatingBar/ParticipationButton.tsx
@@ -16,8 +16,8 @@ interface ParticipationButtonProps {
   user: { name: string; id: number };
   participantCount: number;
   capacity: number;
-  registrationEnd: Date;
-  canceledAt: null | Date;
+  registrationEnd: string;
+  canceledAt: null | string;
   participantsData: Participant[];
 }
 
@@ -36,6 +36,16 @@ const ParticipationButton = ({
     (participant) => participant.User.id === user.id,
   ); //이미 참여했는지 검사
   const isCancelled = Boolean(canceledAt); //취소되었는지 검사
+
+  const isParticipationDisabled = isFull || isRegistrationEnded || isCancelled; // 참여 가능 여부 검사
+
+  const buttonName = hasParticipated ? '참여 취소하기' : '참여하기'; //버튼 이름
+  const buttonVariant = hasParticipated // 버튼 Variant
+    ? 'white'
+    : isParticipationDisabled
+      ? 'gray'
+      : 'default';
+  const buttonAction = hasParticipated ? onWithdraw : onJoin; // 함수 결정
 
   /* 버튼 렌더링 함수 */
   const renderButton = (
@@ -66,12 +76,10 @@ const ParticipationButton = ({
     );
   }
 
-  const isParticipationDisabled = isFull || isRegistrationEnded || isCancelled; // 참여 가능 여부 검사
-
   return renderButton(
-    hasParticipated ? '참여 취소하기' : '참여하기', // 이미 참여했는지 검사
-    hasParticipated ? 'white' : isParticipationDisabled ? 'gray' : 'default', // button 종류 결정
-    hasParticipated ? onWithdraw : onJoin, // 함수 결정
+    buttonName,
+    buttonVariant,
+    buttonAction,
     isParticipationDisabled, // disable 여부
   );
 };

--- a/src/app/components/BottomFloatingBar/ParticipationButton.tsx
+++ b/src/app/components/BottomFloatingBar/ParticipationButton.tsx
@@ -70,7 +70,7 @@ const ParticipationButton = ({
 
   return renderButton(
     hasParticipated ? '참여 취소하기' : '참여하기', // 이미 참여했는지 검사
-    hasParticipated ? 'white' : 'default', // button 종류 결정
+    hasParticipated ? 'white' : isParticipationDisabled ? 'gray' : 'default', // button 종류 결정
     hasParticipated ? onWithdraw : onJoin, // 함수 결정
     isParticipationDisabled, // disable 여부
   );


### PR DESCRIPTION
## ✏️ 작업 내용

-Bottom Floating Bar 컴포넌트 UI 작성

## 📷 스크린샷
# 참가자 UI
## PC화면<br>
<img width="1440" alt="스크린샷 2024-09-09 오후 3 49 22" src="https://github.com/user-attachments/assets/a8abbd7e-8860-4acf-af6f-ca5d8a2c70eb"><br>
## 태블릿 화면<br>
<img width="764" alt="스크린샷 2024-09-09 오후 3 50 08" src="https://github.com/user-attachments/assets/942080af-da65-4066-afbc-1386974e7a34"><br>
## 모바일 화면<br>
<img width="441" alt="스크린샷 2024-09-09 오후 4 03 35" src="https://github.com/user-attachments/assets/1161ac18-e5f4-40ed-ac05-f83139c7074f"><br>
## 참여 불가능할 때<br>
<img width="1192" alt="스크린샷 2024-09-09 오후 4 09 06" src="https://github.com/user-attachments/assets/66bcd75e-e9c1-4340-9826-3a3fbc692eae"><br>

# 주최자 UI
## PC화면<br>
<img width="1439" alt="스크린샷 2024-09-09 오후 4 04 04" src="https://github.com/user-attachments/assets/ce68ee57-eee2-4c65-bd11-55748e3da05c"><br>
## 태블릿 화면<br>
<img width="795" alt="스크린샷 2024-09-09 오후 4 04 36" src="https://github.com/user-attachments/assets/de22708f-0b70-4742-a475-b9c7f69a0464"><br>
## 모바일 화면<br>
<img width="410" alt="스크린샷 2024-09-09 오후 4 04 46" src="https://github.com/user-attachments/assets/ccb67b32-b41b-4fb5-a68a-24566dc4a0e8"><br>



## ✍️ 사용법
```js
      <BottomFloatingBar
        user={user} // 사용자 정보
        createdBy={createdBy} // 모임을 생성한 사용자 ID
        participantCount={participantCount} // 현재 참여자 수
        capacity={capacity} // 모임의 최대 수용 인원
        registrationEnd={registrationEnd} // 등록 마감일
        canceledAt={canceledAt} // 모임 취소일
        participantsData={participantsData} // 참여자 데이터
      />
```
위와 같이 props를 내려주어 사용할 수 있습니다.

## 🎸 기타
실제 api 결과에 따라 props를 변경할 가능성이 있습니다.
