### PR TITLE
feat: 마이페이지 프로필 컴포넌트 UI 작성

### DIFF
--- a/src/app/components/Gnb/Gnb.tsx
+++ b/src/app/components/Gnb/Gnb.tsx
@@ -40,7 +40,7 @@ const Gnb = () => {
   };
 
   return (
-    <header className='bg-var-orange-600 py-16'>
+    <header className='border-b-2 border-var-gray-900 bg-var-orange-600'>
       <div className='mx-16 flex max-w-[1200px] items-center justify-between md:mx-24 lg:mx-auto'>
         <nav className='flex items-center'>
           <Link href='/'>

--- a/src/app/components/UserProfileLayout/Mock.ts
+++ b/src/app/components/UserProfileLayout/Mock.ts
@@ -1,0 +1,6 @@
+export const User = {
+  name: '김수한무',
+  company: '단기심화',
+  email: 'test@test.com',
+  image: null,
+};

--- a/src/app/components/UserProfileLayout/Mock.ts
+++ b/src/app/components/UserProfileLayout/Mock.ts
@@ -2,5 +2,6 @@ export const User = {
   name: '김수한무',
   company: '단기심화',
   email: 'test@test.com',
-  image: null,
+  image:
+    'https://img.animalplanet.co.kr/news/2020/08/05/700/qm05450908o2781sgd75.jpg',
 };

--- a/src/app/components/UserProfileLayout/UserProfileLayout.tsx
+++ b/src/app/components/UserProfileLayout/UserProfileLayout.tsx
@@ -4,7 +4,6 @@ import { BtnEdit, ImageProfile, Profile } from '@/public/images';
 import { User } from './Mock';
 import Image from 'next/image';
 
-const labelStyle = 'text-14 font-medium text-var-gray-800';
 // @todo 프로필 변경 모달 함수작성
 const handleEditProfile = () => {};
 
@@ -33,13 +32,15 @@ const UserProfileLayout = () => {
         <div className='text-16 font-semibold text-var-gray-800'>
           {User.name}
         </div>
-        {/* 회사명 */}
-        <div className={labelStyle}>
-          company.<span className='pl-[6px] font-normal'>{User.company}</span>
-        </div>
-        {/* 이메일 */}
-        <div className={labelStyle}>
-          E-mail. <span className='pl-24 font-normal'>{User.email}</span>
+        <div className='text-14 font-medium text-var-gray-800'>
+          {/* 회사명 */}
+          <div>
+            company.<span className='pl-[6px] font-normal'>{User.company}</span>
+          </div>
+          {/* 이메일 */}
+          <div>
+            E-mail. <span className='pl-24 font-normal'>{User.email}</span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/components/UserProfileLayout/UserProfileLayout.tsx
+++ b/src/app/components/UserProfileLayout/UserProfileLayout.tsx
@@ -9,7 +9,7 @@ const handleEditProfile = () => {};
 
 const UserProfileLayout = () => {
   return (
-    <div className='relative w-full rounded-[24px] border-2 border-var-white'>
+    <div className='relative w-full rounded-[24px] border-2 border-var-gray-200'>
       <div className='flex items-center justify-between rounded-t-[24px] bg-var-orange-400 p-4 px-24 pb-16 pt-[14px]'>
         <div className='text-18 font-semibold text-var-gray-900'>내 프로필</div>
         <ImageProfile className='mx-auto mb-[-26px] h-40 w-156 md:mr-156' />

--- a/src/app/components/UserProfileLayout/UserProfileLayout.tsx
+++ b/src/app/components/UserProfileLayout/UserProfileLayout.tsx
@@ -2,6 +2,7 @@
 
 import { BtnEdit, ImageProfile, Profile } from '@/public/images';
 import { User } from './Mock';
+import Image from 'next/image';
 
 const labelStyle = 'text-14 font-medium text-var-gray-800';
 // @todo 프로필 변경 모달 함수작성
@@ -21,11 +22,13 @@ const UserProfileLayout = () => {
       <div className='h-8 w-full border-t-2 border-var-orange-600 bg-var-orange-400'></div>
       <div className='rounded-b-[24px] bg-var-white px-92 py-16'>
         {/* 프로필 이미지 */}
-        {User.image ? (
-          <div className='size-56'>{User.image}</div>
-        ) : (
-          <Profile className='absolute left-24 top-56 size-56' />
-        )}
+        <div className='absolute left-24 top-56 size-56'>
+          {User.image ? (
+            <img src={User.image} alt='Profile' className='rounded-full' />
+          ) : (
+            <Profile />
+          )}
+        </div>
         {/* 이름 */}
         <div className='text-16 font-semibold text-var-gray-800'>
           {User.name}

--- a/src/app/components/UserProfileLayout/UserProfileLayout.tsx
+++ b/src/app/components/UserProfileLayout/UserProfileLayout.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { BtnEdit, ImageProfile, Profile } from '@/public/images';
+import { User } from './Mock';
+
+const labelStyle = 'text-14 font-medium text-var-gray-800';
+// @todo 프로필 변경 모달 함수작성
+const handleEditProfile = () => {};
+
+const UserProfileLayout = () => {
+  return (
+    <div className='relative w-full rounded-[24px] border-2 border-var-white'>
+      <div className='flex items-center justify-between rounded-t-[24px] bg-var-orange-400 p-4 px-24 pb-16 pt-[14px]'>
+        <div className='text-18 font-semibold text-var-gray-900'>내 프로필</div>
+        <ImageProfile className='mx-auto mb-[-26px] h-40 w-156 md:mr-156' />
+        <button onClick={handleEditProfile}>
+          <BtnEdit className='size-32' />
+        </button>
+      </div>
+      {/* 프로필 헤더 밑줄입니다. */}
+      <div className='h-8 w-full border-t-2 border-var-orange-600 bg-var-orange-400'></div>
+      <div className='rounded-b-[24px] bg-var-white px-92 py-16'>
+        {/* 프로필 이미지 */}
+        {User.image ? (
+          <div className='size-56'>{User.image}</div>
+        ) : (
+          <Profile className='absolute left-24 top-56 size-56' />
+        )}
+        {/* 이름 */}
+        <div className='text-16 font-semibold text-var-gray-800'>
+          {User.name}
+        </div>
+        {/* 회사명 */}
+        <div className={labelStyle}>
+          company.<span className='pl-[6px] font-normal'>{User.company}</span>
+        </div>
+        {/* 이메일 */}
+        <div className={labelStyle}>
+          E-mail. <span className='pl-24 font-normal'>{User.email}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UserProfileLayout;


### PR DESCRIPTION
## ✏️ 작업 내용

-마이페이지 프로필 컴포넌트 UI 입니다.

## 📷 스크린샷

## PC, 태블릿 사이즈
<img width="1015" alt="스크린샷 2024-09-10 오전 10 47 58" src="https://github.com/user-attachments/assets/1ba3b25a-c475-42a3-b083-d969282a1587">


## 모바일 사이즈
<img width="385" alt="스크린샷 2024-09-10 오전 10 48 05" src="https://github.com/user-attachments/assets/b3ea2c6b-10f3-40e4-9479-c95795fdf18e">

## Gnb 스타일 수정 (header py-16 제거 및 밑줄 추가)
<img width="1012" alt="스크린샷 2024-09-10 오전 10 44 57" src="https://github.com/user-attachments/assets/499c29dc-bac3-463d-9057-642458235900">


## ✍️ 사용법
마이페이지 레이아웃에 들어갈 프로필 컴포넌트입니다.
## 🎸 기타