### PR TITLE
feat: 로그인/ 회원가입 페이지 레이아웃 작성

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,33 @@
+import { ImageLogin } from '@/public/images';
+import Footer from '../components/AuthForm/Footer';
+
+const Layout = ({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) => {
+  return (
+    <div className='min-h-dvh w-full bg-var-gray-100'>
+      <div className='flex max-w-[1200px] flex-col items-center justify-between gap-32 pt-40 md:mx-24 lg:mx-auto lg:flex-row lg:pt-40'>
+        <div className='flex flex-col'>
+          <div className='text-center'>
+            <h1 className='text-20 font-semibold md:text-24'>
+              Welcome to 같이 달램!
+            </h1>
+            <p className='text-14 font-medium md:text-16'>
+              바쁜 일상 속 잠깐의 휴식, <br />
+              이제는 같이 달램과 함께 해보세요
+            </p>
+          </div>
+          <ImageLogin className='w-[588px]' />
+        </div>
+        <div className='rounded-[24px] bg-var-white px-[54px] py-32'>
+          {children}
+          <Footer />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -8,20 +8,21 @@ const Layout = ({
 }>) => {
   return (
     <div className='min-h-dvh w-full bg-var-gray-100'>
-      <div className='flex max-w-[1200px] flex-col items-center justify-between gap-32 pt-40 md:mx-24 lg:mx-auto lg:flex-row lg:pt-40'>
-        <div className='flex flex-col'>
-          <div className='text-center'>
-            <h1 className='text-20 font-semibold md:text-24'>
-              Welcome to 같이 달램!
-            </h1>
-            <p className='text-14 font-medium md:text-16'>
-              바쁜 일상 속 잠깐의 휴식, <br />
-              이제는 같이 달램과 함께 해보세요
-            </p>
-          </div>
-          <ImageLogin className='w-[588px]' />
+      <div className='flex flex-col items-center justify-between gap-32 py-40 md:mx-24 lg:mx-auto lg:max-w-[1200px] lg:flex-row lg:gap-100 lg:px-24 lg:pt-40'>
+        {/* 이미지 영역 */}
+        <div className='text-center'>
+          <h1 className='text-20 font-semibold md:text-24'>
+            Welcome to 같이 달램!
+          </h1>
+          <p className='text-14 font-medium md:text-16'>
+            바쁜 일상 속 잠깐의 휴식, <br />
+            이제는 같이 달램과 함께 해보세요
+          </p>
+          <ImageLogin className='w-[290px] md:w-[407px] lg:w-[588px]' />
         </div>
-        <div className='rounded-[24px] bg-var-white px-[54px] py-32'>
+
+        {/* form 영역 */}
+        <div className='w-[343px] rounded-[24px] bg-var-white px-16 py-32 md:w-[510px] md:px-[54px]'>
           {children}
           <Footer />
         </div>

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,0 +1,14 @@
+import LoginForm from '@/app/components/AuthForm/LoginForm';
+
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '로그인 | Soothe With Me',
+  description: 'Soothe Wit hMe 로그인 페이지입니다.',
+};
+
+const SignIn = () => {
+  return <LoginForm />;
+};
+
+export default SignIn;

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,14 +1,13 @@
-import LoginForm from '@/app/components/AuthForm/LoginForm';
-
+import SignInForm from '@/app/components/AuthForm/SignInForm';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: '로그인 | Soothe With Me',
-  description: 'Soothe Wit hMe 로그인 페이지입니다.',
+  description: 'Soothe With Me 로그인 페이지입니다.',
 };
 
 const SignIn = () => {
-  return <LoginForm />;
+  return <SignInForm />;
 };
 
 export default SignIn;

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,13 @@
+import SignUpForm from '@/app/components/AuthForm/SignUpForm';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '회원가입 | Soothe With Me',
+  description: 'Soothe With Me 회원가입 페이지입니다.',
+};
+
+const SignUp = () => {
+  return <SignUpForm />;
+};
+
+export default SignUp;

--- a/src/app/components/AuthForm/Footer.tsx
+++ b/src/app/components/AuthForm/Footer.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const Footer = () => {
+  const pathname = usePathname();
+  const isSignIn = pathname === '/signin';
+  const spanText = isSignIn
+    ? '같이 달램이 처음 이신가요? '
+    : '이미 회원이신가요? ';
+  const linkText = isSignIn ? '회원가입' : '로그인';
+  const linkSrc = isSignIn ? 'signup' : 'signin';
+
+  return (
+    <div className='flex items-center justify-center gap-4 pt-24 text-[15px] font-medium'>
+      <span className='flex items-center justify-center text-[15px] font-medium'>
+        {spanText}
+      </span>
+      <Link className='text-var-orange-600 underline' href={linkSrc}>
+        {linkText}
+      </Link>
+    </div>
+  );
+};
+export default Footer;

--- a/src/app/components/AuthForm/FormOptions.ts
+++ b/src/app/components/AuthForm/FormOptions.ts
@@ -1,0 +1,66 @@
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; //이메일 형식 검사하는 정규식
+const passwordPattern = /^(?=.*\d)[A-Za-z\d]{8,}$/; //숫자와 문자를 포함하여 8자 이상인지 검사하는 정규식
+
+export const FORM_OPTIONS = {
+  /* 이메일 유효성 검사 */
+  email: {
+    name: 'email' as const,
+    placeholder: '이메일을 입력해 주세요.',
+    rules: {
+      required: '이메일을 입력해 주세요.',
+      pattern: {
+        value: emailPattern,
+        message: '올바른 이메일 주소가 아닙니다.',
+      },
+    },
+  },
+  /* 로그인시 비밀번호 유효성 검사 */
+  loginPassword: {
+    name: 'password' as const,
+    placeholder: '비밀번호를 입력해 주세요',
+    rules: {
+      required: '비밀번호를 입력해 주세요.',
+    },
+  },
+  /* 이름 유효성 검사 */
+  nameCheck: {
+    name: 'name' as const,
+    placeholder: '이름을 입력해 주세요',
+    rules: {
+      required: '이름을 입력해 주세요.',
+    },
+  },
+  /* 회사명 유효성 검사 */
+  companyName: {
+    name: 'companyName' as const,
+    placeholder: '회사명을 입력해 주세요.',
+    rules: {
+      required: '회사명을 입력해 주세요.',
+    },
+  },
+  /* 회원가입시 비밀번호 유효성 검사 */
+  password: {
+    name: 'password' as const,
+    placeholder: '비밀번호를 입력해 주세요',
+    rules: {
+      required: '비밀번호를 입력해 주세요.',
+      pattern: {
+        value: passwordPattern,
+        message: '비밀번호가 8자 이상이 되도록 해 주세요.',
+      },
+    },
+  },
+  /* 회원가입시 비밀번호 확인 유효성 검사 */
+  passwordCheck: {
+    name: 'passwordCheck' as const,
+    placeholder: '비밀번호를 다시 한 번 입력해주세요.',
+    rules: {
+      required: '비밀번호를 입력해 주세요.',
+    },
+    validateMsg: '비밀번호가 일치하지 않습니다.',
+  },
+  /* 오류 메시지 스타일링 */
+  errorMessageStyle: 'text-var-red text-14 mt-4',
+};
+
+export default FORM_OPTIONS;

--- a/src/app/components/AuthForm/FormOptions.ts
+++ b/src/app/components/AuthForm/FormOptions.ts
@@ -32,7 +32,7 @@ export const FORM_OPTIONS = {
   },
   /* 회사명 유효성 검사 */
   companyName: {
-    name: 'companyName' as const,
+    name: 'company' as const,
     placeholder: '회사명을 입력해 주세요.',
     rules: {
       required: '회사명을 입력해 주세요.',
@@ -56,9 +56,12 @@ export const FORM_OPTIONS = {
     placeholder: '비밀번호를 다시 한 번 입력해주세요.',
     rules: {
       required: '비밀번호를 입력해 주세요.',
+      validate: (value: string, formValues: { password: string }) =>
+        value === formValues.password || '비밀번호가 일치하지 않습니다.',
     },
     validateMsg: '비밀번호가 일치하지 않습니다.',
   },
+
   /* 오류 메시지 스타일링 */
   errorMessageStyle: 'text-var-red text-14 mt-4',
 };

--- a/src/app/components/AuthForm/LoginForm.tsx
+++ b/src/app/components/AuthForm/LoginForm.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Controller, useForm } from 'react-hook-form';
+import Button from '../Button/Button';
+import Input from '../Input/Input';
+import Link from 'next/link';
+
+interface LoginData {
+  email: string;
+  password: string;
+}
+
+const LoginForm = () => {
+  return (
+    <form className='max-w-[510px] rounded-[24px] bg-var-white px-[54px] py-32'>
+      <div className='flex w-full flex-col gap-24'>
+        <h1 className='pb-8 text-center text-24 font-semibold'>로그인</h1>
+        <div className='flex flex-col gap-4'>
+          <label className='text-14 font-semibold'>아이디</label>
+          <Input placeholder='이메일을 입려해주세요.' className='h-44' />
+        </div>
+        <div className='flex flex-col gap-4'>
+          <label className='text-14 font-semibold'>비밀번호</label>
+          <Input
+            placeholder='비밀번호를 입력해주세요.'
+            className='mb-16 h-44'
+          />
+        </div>
+        <Button
+          type='submit'
+          name='로그인 하기'
+          variant='default'
+          disabled={false}
+        />
+        <p className='flex items-center justify-center text-[15px] font-medium'>
+          같이 달램이 처음이신가요?
+          <span className='text-var-orange-600 underline'>
+            <Link href='/signup'>회원가입</Link>
+          </span>
+        </p>
+      </div>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/src/app/components/AuthForm/SignInForm.tsx
+++ b/src/app/components/AuthForm/SignInForm.tsx
@@ -13,7 +13,7 @@ interface SigninnData {
 const SignInForm = () => {
   return (
     <form className='rounded-[24px] bg-var-white'>
-      <div className='flex w-full flex-col gap-24'>
+      <div className='flex flex-col gap-24'>
         <h1 className='pb-8 text-center text-24 font-semibold'>로그인</h1>
         <div className='flex flex-col gap-4'>
           <label className='text-14 font-semibold'>아이디</label>

--- a/src/app/components/AuthForm/SignInForm.tsx
+++ b/src/app/components/AuthForm/SignInForm.tsx
@@ -81,8 +81,8 @@ const SignInForm = () => {
         <Button
           type='submit'
           name='로그인'
-          variant='default'
-          disabled={false}
+          variant={isValid ? 'default' : 'gray'}
+          disabled={!isValid}
         />
       </div>
     </form>

--- a/src/app/components/AuthForm/SignInForm.tsx
+++ b/src/app/components/AuthForm/SignInForm.tsx
@@ -3,28 +3,80 @@
 import { Controller, useForm } from 'react-hook-form';
 import Button from '../Button/Button';
 import Input from '../Input/Input';
-import Link from 'next/link';
+import FORM_OPTIONS from './FormOptions';
 
-interface SigninnData {
+interface SignInData {
   email: string;
   password: string;
 }
 
 const SignInForm = () => {
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<SignInData>({
+    mode: 'onChange',
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
+
+  //@todo 제출 함수 작성
+  const submit = (data: SignInData) => {
+    console.log(data);
+  };
   return (
-    <form className='rounded-[24px] bg-var-white'>
+    <form
+      className='rounded-[24px] bg-var-white'
+      onSubmit={handleSubmit(submit)}
+    >
       <div className='flex flex-col gap-24'>
         <h1 className='pb-8 text-center text-24 font-semibold'>로그인</h1>
         <div className='flex flex-col gap-4'>
           <label className='text-14 font-semibold'>아이디</label>
-          <Input placeholder='이메일을 입려해주세요.' className='h-44' />
+          <Controller
+            control={control}
+            name={FORM_OPTIONS.email.name}
+            rules={FORM_OPTIONS.email.rules}
+            defaultValue=''
+            render={({ field }) => (
+              <Input
+                placeholder='이메일을 입려해주세요.'
+                className='h-44'
+                hasError={!!errors.email}
+                {...field}
+              />
+            )}
+          />
+          {errors.email && (
+            <div className={FORM_OPTIONS.errorMessageStyle}>
+              {errors.email.message}
+            </div>
+          )}
         </div>
         <div className='flex flex-col gap-4'>
           <label className='text-14 font-semibold'>비밀번호</label>
-          <Input
-            placeholder='비밀번호를 입력해주세요.'
-            className='mb-16 h-44'
+          <Controller
+            control={control}
+            name={FORM_OPTIONS.loginPassword.name}
+            rules={FORM_OPTIONS.loginPassword.rules}
+            defaultValue=''
+            render={({ field }) => (
+              <Input
+                placeholder='비밀번호를 입력해주세요.'
+                className='h-44'
+                hasError={!!errors.password}
+                {...field}
+              />
+            )}
           />
+          {errors.password && (
+            <div className={FORM_OPTIONS.errorMessageStyle}>
+              {errors.password.message}
+            </div>
+          )}
         </div>
         <Button
           type='submit'

--- a/src/app/components/AuthForm/SignInForm.tsx
+++ b/src/app/components/AuthForm/SignInForm.tsx
@@ -12,7 +12,7 @@ interface LoginData {
 
 const LoginForm = () => {
   return (
-    <form className='max-w-[510px] rounded-[24px] bg-var-white px-[54px] py-32'>
+    <form className='rounded-[24px] bg-var-white'>
       <div className='flex w-full flex-col gap-24'>
         <h1 className='pb-8 text-center text-24 font-semibold'>로그인</h1>
         <div className='flex flex-col gap-4'>
@@ -32,12 +32,6 @@ const LoginForm = () => {
           variant='default'
           disabled={false}
         />
-        <p className='flex items-center justify-center text-[15px] font-medium'>
-          같이 달램이 처음이신가요?
-          <span className='text-var-orange-600 underline'>
-            <Link href='/signup'>회원가입</Link>
-          </span>
-        </p>
       </div>
     </form>
   );

--- a/src/app/components/AuthForm/SignInForm.tsx
+++ b/src/app/components/AuthForm/SignInForm.tsx
@@ -5,12 +5,12 @@ import Button from '../Button/Button';
 import Input from '../Input/Input';
 import Link from 'next/link';
 
-interface LoginData {
+interface SigninnData {
   email: string;
   password: string;
 }
 
-const LoginForm = () => {
+const SignInForm = () => {
   return (
     <form className='rounded-[24px] bg-var-white'>
       <div className='flex w-full flex-col gap-24'>
@@ -28,7 +28,7 @@ const LoginForm = () => {
         </div>
         <Button
           type='submit'
-          name='로그인 하기'
+          name='로그인'
           variant='default'
           disabled={false}
         />
@@ -37,4 +37,4 @@ const LoginForm = () => {
   );
 };
 
-export default LoginForm;
+export default SignInForm;

--- a/src/app/components/AuthForm/SignUpForm.tsx
+++ b/src/app/components/AuthForm/SignUpForm.tsx
@@ -3,43 +3,146 @@
 import { Controller, useForm } from 'react-hook-form';
 import Button from '../Button/Button';
 import Input from '../Input/Input';
-import Link from 'next/link';
+import FORM_OPTIONS from './FormOptions';
 
-interface LoginData {
+interface SignUpData {
+  name: string;
   email: string;
+  company: string;
   password: string;
+  passwordCheck: string;
 }
 
 const SignUpForm = () => {
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<SignUpData>({
+    mode: 'onChange',
+    defaultValues: {
+      name: '',
+      email: '',
+      company: '',
+      password: '',
+      passwordCheck: '',
+    },
+  });
+
+  const submit = (data: SignUpData) => {
+    console.log(data);
+  };
   return (
-    <form className='rounded-[24px] bg-var-white'>
+    <form
+      className='rounded-[24px] bg-var-white'
+      onSubmit={handleSubmit(submit)}
+    >
       <div className='flex w-full flex-col gap-24'>
         <h1 className='pb-8 text-center text-24 font-semibold'>회원가입</h1>
         <div className='flex flex-col gap-4'>
           <label className='text-14 font-semibold'>이름</label>
-          <Input placeholder='이메일을 입려해주세요.' className='h-44' />
+          <Controller
+            control={control}
+            name={FORM_OPTIONS.nameCheck.name}
+            rules={FORM_OPTIONS.nameCheck.rules}
+            render={({ field }) => (
+              <Input
+                placeholder='이름을 입려해주세요.'
+                className='h-44'
+                hasError={!!errors.name}
+                {...field}
+              />
+            )}
+          />
+          {errors.name && (
+            <div className={FORM_OPTIONS.errorMessageStyle}>
+              {errors.name.message}
+            </div>
+          )}
         </div>
         <div className='flex flex-col gap-4'>
           <label className='text-14 font-semibold'>아이디</label>
-          <Input placeholder='이메일을 입려해주세요.' className='h-44' />
+          <Controller
+            control={control}
+            name={FORM_OPTIONS.email.name}
+            rules={FORM_OPTIONS.email.rules}
+            render={({ field }) => (
+              <Input
+                placeholder='이메일을 입려해주세요.'
+                className='h-44'
+                hasError={!!errors.email}
+                {...field}
+              />
+            )}
+          />
+          {errors.email && (
+            <div className={FORM_OPTIONS.errorMessageStyle}>
+              {errors.email.message}
+            </div>
+          )}
         </div>
         <div className='flex flex-col gap-4'>
           <label className='text-14 font-semibold'>회사명</label>
-          <Input placeholder='이메일을 입려해주세요.' className='h-44' />
+          <Controller
+            control={control}
+            name={FORM_OPTIONS.companyName.name}
+            rules={FORM_OPTIONS.companyName.rules}
+            render={({ field }) => (
+              <Input
+                placeholder='회사명을 입려해주세요.'
+                className='h-44'
+                hasError={!!errors.company}
+                {...field}
+              />
+            )}
+          />
+          {errors.company && (
+            <div className={FORM_OPTIONS.errorMessageStyle}>
+              {errors.company.message}
+            </div>
+          )}
         </div>
         <div className='flex flex-col gap-4'>
           <label className='text-14 font-semibold'>비밀번호</label>
-          <Input
-            placeholder='비밀번호를 입력해주세요.'
-            className='mb-16 h-44'
+          <Controller
+            control={control}
+            name={FORM_OPTIONS.password.name}
+            rules={FORM_OPTIONS.password.rules}
+            render={({ field }) => (
+              <Input
+                placeholder='비밀번호를 입력해주세요.'
+                className='mb-16 h-44'
+                hasError={!!errors.password}
+                {...field}
+              />
+            )}
           />
+          {errors.password && (
+            <div className={FORM_OPTIONS.errorMessageStyle}>
+              {errors.password.message}
+            </div>
+          )}
         </div>
         <div className='flex flex-col gap-4'>
           <label className='text-14 font-semibold'>비밀번호 확인</label>
-          <Input
-            placeholder='비밀번호를 입력해주세요.'
-            className='mb-16 h-44'
+          <Controller
+            control={control}
+            name={FORM_OPTIONS.passwordCheck.name}
+            rules={FORM_OPTIONS.passwordCheck.rules}
+            render={({ field }) => (
+              <Input
+                placeholder='비밀번호를 다시 한 번 입력해주세요.'
+                className='h-44'
+                hasError={!!errors.passwordCheck}
+                {...field}
+              />
+            )}
           />
+          {errors.passwordCheck && (
+            <div className={FORM_OPTIONS.errorMessageStyle}>
+              {errors.passwordCheck.message}
+            </div>
+          )}
         </div>
         <Button type='submit' name='확인' variant='default' disabled={false} />
       </div>

--- a/src/app/components/AuthForm/SignUpForm.tsx
+++ b/src/app/components/AuthForm/SignUpForm.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Controller, useForm } from 'react-hook-form';
+import Button from '../Button/Button';
+import Input from '../Input/Input';
+import Link from 'next/link';
+
+interface LoginData {
+  email: string;
+  password: string;
+}
+
+const SignUpForm = () => {
+  return (
+    <form className='rounded-[24px] bg-var-white'>
+      <div className='flex w-full flex-col gap-24'>
+        <h1 className='pb-8 text-center text-24 font-semibold'>회원가입</h1>
+        <div className='flex flex-col gap-4'>
+          <label className='text-14 font-semibold'>이름</label>
+          <Input placeholder='이메일을 입려해주세요.' className='h-44' />
+        </div>
+        <div className='flex flex-col gap-4'>
+          <label className='text-14 font-semibold'>아이디</label>
+          <Input placeholder='이메일을 입려해주세요.' className='h-44' />
+        </div>
+        <div className='flex flex-col gap-4'>
+          <label className='text-14 font-semibold'>회사명</label>
+          <Input placeholder='이메일을 입려해주세요.' className='h-44' />
+        </div>
+        <div className='flex flex-col gap-4'>
+          <label className='text-14 font-semibold'>비밀번호</label>
+          <Input
+            placeholder='비밀번호를 입력해주세요.'
+            className='mb-16 h-44'
+          />
+        </div>
+        <div className='flex flex-col gap-4'>
+          <label className='text-14 font-semibold'>비밀번호 확인</label>
+          <Input
+            placeholder='비밀번호를 입력해주세요.'
+            className='mb-16 h-44'
+          />
+        </div>
+        <Button type='submit' name='확인' variant='default' disabled={false} />
+      </div>
+    </form>
+  );
+};
+
+export default SignUpForm;

--- a/src/app/components/AuthForm/SignUpForm.tsx
+++ b/src/app/components/AuthForm/SignUpForm.tsx
@@ -144,7 +144,12 @@ const SignUpForm = () => {
             </div>
           )}
         </div>
-        <Button type='submit' name='확인' variant='default' disabled={false} />
+        <Button
+          type='submit'
+          name='확인'
+          variant={isValid ? 'default' : 'gray'}
+          disabled={!isValid}
+        />
       </div>
     </form>
   );

--- a/src/app/components/Input/Input.tsx
+++ b/src/app/components/Input/Input.tsx
@@ -4,7 +4,7 @@ import { forwardRef, InputHTMLAttributes } from 'react';
 
 // @todo: 추후 파일 분리예정
 export const InputStyles = {
-  base: 'w-full items-center gap-4 rounded-lg px-16 py-8 focus:ring-2',
+  base: 'w-full bg-var-gray-50 text-16 items-center gap-4 rounded-lg px-16 py-8 focus:ring-2',
   hover: 'hover:ring-2 hover:ring-var-orange-300',
   focus: 'focus:ring-var-orange-600',
   error: 'ring-var-red ring-2', // form 사용시 에러메시지용 레이아웃


### PR DESCRIPTION
## ✏️ 작업 내용

-로그인 페이지 레이아웃 작성
-회원가입 페이지 레이아웃 작성
-클라이언트에서 할 수 있는 유효성 검사 추가

## 📷 스크린샷
## 로그인 페이지 
<img width="1407" alt="스크린샷 2024-09-10 오후 5 42 17" src="https://github.com/user-attachments/assets/ace3626f-7ccd-4908-868c-20378366d18d">

## 회원가입 페이지
<img width="1323" alt="스크린샷 2024-09-10 오후 5 41 55" src="https://github.com/user-attachments/assets/03a9a16e-a010-486e-b759-d7f225941e77">

## 폼 내용 채우지 않을 시 제출 버튼 비활성화
<img width="500" alt="스크린샷 2024-09-10 오후 5 44 12" src="https://github.com/user-attachments/assets/77813df4-622d-476c-b660-87316d4ce675">

## 제출버튼 활성화

<img width="517" alt="스크린샷 2024-09-10 오후 5 44 49" src="https://github.com/user-attachments/assets/3b7c4ca3-633d-41f9-977e-9b3f0bbe2764">

## 유효성 검사 오류 화면

<img width="531" alt="스크린샷 2024-09-10 오후 5 47 57" src="https://github.com/user-attachments/assets/8cb49906-1691-4e3f-9ac9-e263c367a419">



## ✍️ 사용법

- 로그인 및 회원가입 페이지 레이아웃입니다.
- 각각 /signin /signup 페이지를 통해서 들어갈 수 있습니다.
- 현재는 값 작성 여부 및 클라이언트에서 검사할 수 있는 유효성 검사가 진행됩니다.

## 🎸 기타

- [x] 비밀번호 toggle 버튼 추가 예정
- [x] 폼 에러메시지 애니메이션 추가 예정
