### PR TITLE
test: input UI 컴포넌트 테스트 코드 작성

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ const createJestConfig = nextJest({
 const config = {
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,6 @@ const createJestConfig = nextJest({
 const config = {
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,14 @@ const createJestConfig = nextJest({
 const config = {
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
+  rootDir: './',
+  moduleNameMapper: {
+    '^@/public/(.*)$': '<rootDir>/public/$1', // public 폴더 매핑
+    '^@/(.*)$': '<rootDir>/src/$1', // src 폴더 매핑
+  },
+  modulePaths: ['<rootDir>'],
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json', 'node'],
+  moduleDirectories: ['node_modules', '<rootDir>'],
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 };

--- a/src/app/components/Input/Input.test.tsx
+++ b/src/app/components/Input/Input.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import Input from './Input';
 import '@testing-library/jest-dom';
+import { createRef } from 'react';
 
 describe('Input Component', () => {
   it('기본 렌더링', () => {
@@ -38,5 +39,20 @@ describe('Input Component', () => {
     render(<Input className='h-[200px]' />);
     const inputElement = screen.getByRole('textbox');
     expect(inputElement).toHaveClass('h-[200px]');
+  });
+
+  it('className과 hasError prop이 동시에 적용될 때 className 스타일과 에러 스타일이 모두 적용된다.', () => {
+    render(<Input className='h-[200px]' hasError />);
+    const inputElement = screen.getByRole('textbox');
+    expect(inputElement).toHaveClass('h-[200px]');
+    expect(inputElement).toHaveClass('ring-var-red ring-2');
+  });
+
+  it('ref가 제대로 설정된다', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<Input ref={ref} />);
+
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    expect(ref.current).toBeInTheDocument();
   });
 });

--- a/src/app/components/Input/Input.test.tsx
+++ b/src/app/components/Input/Input.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import Input from './Input';
+import '@testing-library/jest-dom';
 
 describe('Input Component', () => {
   it('기본 렌더링', () => {

--- a/src/app/components/Input/Input.test.tsx
+++ b/src/app/components/Input/Input.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Input from './Input';
+
+describe('Input Component', () => {
+  it('기본 렌더링', () => {
+    render(<Input placeholder='test' />);
+
+    const inputElement = screen.getByRole('textbox');
+    expect(inputElement).toBeInTheDocument();
+  });
+
+  it('플레이스홀더 텍스트가 제대로 표시된다', () => {
+    render(<Input placeholder='이메일을 입력해주세요.' />);
+    const inputElement = screen.getByPlaceholderText('이메일을 입력해주세요.');
+    expect(inputElement).toBeInTheDocument();
+  });
+
+  it('입력 값이 올바르게 설정된다', () => {
+    render(<Input value='test@example.com' />);
+    const inputElement = screen.getByDisplayValue('test@example.com');
+    expect(inputElement).toBeInTheDocument();
+  });
+
+  it('type 속성이 제대로 설정된다', () => {
+    render(<Input type='password' aria-label='Input' />);
+    const inputElement = screen.getByLabelText('Input');
+    expect(inputElement).toHaveAttribute('type', 'password');
+  });
+
+  it('hasError prop이 true일 때 에러 스타일이 적용된다', () => {
+    render(<Input hasError />);
+    const inputElement = screen.getByRole('textbox');
+    expect(inputElement).toHaveClass('ring-var-red ring-2');
+  });
+
+  it('className prop이 적용된다', () => {
+    render(<Input className='custom-class' />);
+    const inputElement = screen.getByRole('textbox');
+    expect(inputElement).toHaveClass('custom-class');
+  });
+});

--- a/src/app/components/Input/Input.test.tsx
+++ b/src/app/components/Input/Input.test.tsx
@@ -17,7 +17,7 @@ describe('Input Component', () => {
   });
 
   it('입력 값이 올바르게 설정된다', () => {
-    render(<Input value='test@example.com' />);
+    render(<Input value='test@example.com' onChange={() => {}} />);
     const inputElement = screen.getByDisplayValue('test@example.com');
     expect(inputElement).toBeInTheDocument();
   });
@@ -35,8 +35,8 @@ describe('Input Component', () => {
   });
 
   it('className prop이 적용된다', () => {
-    render(<Input className='custom-class' />);
+    render(<Input className='h-[200px]' />);
     const inputElement = screen.getByRole('textbox');
-    expect(inputElement).toHaveClass('custom-class');
+    expect(inputElement).toHaveClass('h-[200px]');
   });
 });

--- a/src/app/components/Input/Input.test.tsx
+++ b/src/app/components/Input/Input.test.tsx
@@ -4,51 +4,59 @@ import '@testing-library/jest-dom';
 import { createRef } from 'react';
 
 describe('Input Component', () => {
-  it('기본 렌더링', () => {
+  /* 기본 렌더링 */
+  it('renders correctly', () => {
     render(<Input placeholder='test' />);
 
     const inputElement = screen.getByRole('textbox');
     expect(inputElement).toBeInTheDocument();
   });
 
-  it('플레이스홀더 텍스트가 제대로 표시된다', () => {
-    render(<Input placeholder='이메일을 입력해주세요.' />);
-    const inputElement = screen.getByPlaceholderText('이메일을 입력해주세요.');
+  /* 플레이스홀더 텍스트가 제대로 표시된다 */
+  it('displays placeholder text correctly', () => {
+    render(<Input placeholder='Enter your email' />);
+    const inputElement = screen.getByPlaceholderText('Enter your email');
     expect(inputElement).toBeInTheDocument();
   });
 
-  it('입력 값이 올바르게 설정된다', () => {
+  /* 입력 값이 올바르게 설정된다 */
+  it('sets input value correctly', () => {
     render(<Input value='test@example.com' onChange={() => {}} />);
     const inputElement = screen.getByDisplayValue('test@example.com');
     expect(inputElement).toBeInTheDocument();
   });
 
-  it('type 속성이 제대로 설정된다', () => {
+  /* type 속성이 제대로 설정된다 */
+  it('sets type attribute correctly', () => {
     render(<Input type='password' aria-label='Input' />);
     const inputElement = screen.getByLabelText('Input');
     expect(inputElement).toHaveAttribute('type', 'password');
   });
 
-  it('hasError prop이 true일 때 에러 스타일이 적용된다', () => {
+  /* hasError prop이 true일 때 에러 스타일이 적용된다 */
+  it('applies error styles when hasError is true', () => {
     render(<Input hasError />);
     const inputElement = screen.getByRole('textbox');
     expect(inputElement).toHaveClass('ring-var-red ring-2');
   });
 
-  it('className prop이 적용된다', () => {
+  /* className prop이 적용된다 */
+  it('applies className prop', () => {
     render(<Input className='h-[200px]' />);
     const inputElement = screen.getByRole('textbox');
     expect(inputElement).toHaveClass('h-[200px]');
   });
 
-  it('className과 hasError prop이 동시에 적용될 때 className 스타일과 에러 스타일이 모두 적용된다.', () => {
+  /* className과 hasError prop이 동시에 적용될 때 className 스타일과 에러 스타일이 모두 적용된다 */
+  it('applies both className and error styles when both props are set', () => {
     render(<Input className='h-[200px]' hasError />);
     const inputElement = screen.getByRole('textbox');
     expect(inputElement).toHaveClass('h-[200px]');
     expect(inputElement).toHaveClass('ring-var-red ring-2');
   });
 
-  it('ref가 제대로 설정된다', () => {
+  /* ref가 제대로 설정된다 */
+  it('sets ref correctly', () => {
     const ref = createRef<HTMLInputElement>();
     render(<Input ref={ref} />);
 

--- a/src/app/components/Input/Input.tsx
+++ b/src/app/components/Input/Input.tsx
@@ -32,6 +32,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     return (
       <input
         ref={ref}
+        type={type}
         className={`${InputStyles.base} hover: ${InputStyles.hover} focus: ${InputStyles.focus} ${hasError && InputStyles.error} ${className}`}
         {...rest}
       />

--- a/src/app/components/Input/Input.tsx
+++ b/src/app/components/Input/Input.tsx
@@ -13,6 +13,7 @@ export const InputStyles = {
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   hasError?: boolean;
   className?: string;
+  type?: 'text' | 'password';
 }
 
 /**
@@ -27,7 +28,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
  * @param {Ref<HTMLInputElement>} ref - forwardRef를 사용하여 전달받은 ref
  */
 const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ hasError = false, className = '', ...rest }, ref) => {
+  ({ hasError = false, className = '', type = 'text', ...rest }, ref) => {
     return (
       <input
         ref={ref}

--- a/src/app/components/Input/InputText.test.tsx
+++ b/src/app/components/Input/InputText.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InputText from './InputText';
+
+describe('InputText 컴포넌트', () => {
+  it('기본 렌더링', () => {
+    render(<InputText value='' onChange={() => {}} />);
+    const textareaElement = screen.getByRole('textbox');
+    expect(textareaElement).toBeInTheDocument();
+  });
+
+  it('플레이스홀더 텍스트가 제대로 표시된다', () => {
+    render(
+      <InputText
+        value=''
+        placeholder='할 일의 제목을 적어주세요.'
+        onChange={() => {}}
+      />,
+    );
+    const textareaElement =
+      screen.getByPlaceholderText('할 일의 제목을 적어주세요.');
+    expect(textareaElement).toBeInTheDocument();
+  });
+
+  it('입력 값이 올바르게 설정된다', () => {
+    render(<InputText value='test@example.com' onChange={() => {}} />);
+    const textareaElement = screen.getByDisplayValue('test@example.com');
+    expect(textareaElement).toBeInTheDocument();
+  });
+
+  it('className prop이 적용된다', () => {
+    render(<InputText value='' className='h-[200px]' onChange={() => {}} />);
+    const textareaElement = screen.getByRole('textbox');
+    expect(textareaElement).toHaveClass('h-[200px]');
+  });
+
+  it('onChange 핸들러가 호출된다', () => {
+    const handleChange = jest.fn();
+    render(<InputText value='' onChange={handleChange} />);
+    const textareaElement = screen.getByRole('textbox');
+    fireEvent.change(textareaElement, { target: { value: 'new value' } });
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/components/Input/InputText.test.tsx
+++ b/src/app/components/Input/InputText.test.tsx
@@ -41,4 +41,16 @@ describe('InputText 컴포넌트', () => {
     fireEvent.change(textareaElement, { target: { value: 'new value' } });
     expect(handleChange).toHaveBeenCalledTimes(1);
   });
+
+  it('spellCheck 속성이 true로 설정된다', () => {
+    render(<InputText value='' spellCheck={true} onChange={() => {}} />);
+    const textareaElement = screen.getByRole('textbox');
+    expect(textareaElement).toHaveAttribute('spellcheck', 'true');
+  });
+
+  it('spellCheck 속성이 false로 설정된다', () => {
+    render(<InputText value='' spellCheck={false} onChange={() => {}} />);
+    const textareaElement = screen.getByRole('textbox');
+    expect(textareaElement).toHaveAttribute('spellcheck', 'false');
+  });
 });

--- a/src/app/components/Input/InputText.test.tsx
+++ b/src/app/components/Input/InputText.test.tsx
@@ -3,13 +3,15 @@ import '@testing-library/jest-dom';
 import InputText from './InputText';
 
 describe('InputText 컴포넌트', () => {
-  it('기본 렌더링', () => {
+  /* 기본 렌더링 테스트 */
+  it('renders correctly', () => {
     render(<InputText value='' onChange={() => {}} />);
     const textareaElement = screen.getByRole('textbox');
     expect(textareaElement).toBeInTheDocument();
   });
 
-  it('플레이스홀더 텍스트가 제대로 표시된다', () => {
+  /* 플레이스홀더 텍스트가 제대로 표시되는지 테스트 */
+  it('displays placeholder text correctly', () => {
     render(
       <InputText
         value=''
@@ -22,19 +24,22 @@ describe('InputText 컴포넌트', () => {
     expect(textareaElement).toBeInTheDocument();
   });
 
-  it('입력 값이 올바르게 설정된다', () => {
+  /* 입력 값이 올바르게 설정되는지 테스트 */
+  it('sets input value correctly', () => {
     render(<InputText value='test@example.com' onChange={() => {}} />);
     const textareaElement = screen.getByDisplayValue('test@example.com');
     expect(textareaElement).toBeInTheDocument();
   });
 
-  it('className prop이 적용된다', () => {
+  /* className 속성이 적용되는지 테스트 */
+  it('applies className prop', () => {
     render(<InputText value='' className='h-[200px]' onChange={() => {}} />);
     const textareaElement = screen.getByRole('textbox');
     expect(textareaElement).toHaveClass('h-[200px]');
   });
 
-  it('onChange 핸들러가 호출된다', () => {
+  /* onChange 핸들러가 호출되는지 테스트 */
+  it('calls onChange handler', () => {
     const handleChange = jest.fn();
     render(<InputText value='' onChange={handleChange} />);
     const textareaElement = screen.getByRole('textbox');
@@ -42,13 +47,15 @@ describe('InputText 컴포넌트', () => {
     expect(handleChange).toHaveBeenCalledTimes(1);
   });
 
-  it('spellCheck 속성이 true로 설정된다', () => {
+  /* spellCheck 속성이 true로 설정되는지 테스트 */
+  it('sets spellCheck attribute to true', () => {
     render(<InputText value='' spellCheck={true} onChange={() => {}} />);
     const textareaElement = screen.getByRole('textbox');
     expect(textareaElement).toHaveAttribute('spellcheck', 'true');
   });
 
-  it('spellCheck 속성이 false로 설정된다', () => {
+  /* spellCheck 속성이 false로 설정되는지 테스트 */
+  it('sets spellCheck attribute to false', () => {
     render(<InputText value='' spellCheck={false} onChange={() => {}} />);
     const textareaElement = screen.getByRole('textbox');
     expect(textareaElement).toHaveAttribute('spellcheck', 'false');

--- a/src/app/components/Input/InputText.tsx
+++ b/src/app/components/Input/InputText.tsx
@@ -8,6 +8,7 @@ interface InputTextProps {
   placeholder?: string;
   onChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
   className?: string;
+  spellCheck?: boolean;
 }
 
 /**
@@ -23,6 +24,7 @@ const InputText = ({
   placeholder = '',
   onChange,
   className = '',
+  spellCheck = false,
 }: InputTextProps) => {
   return (
     <textarea
@@ -30,7 +32,7 @@ const InputText = ({
       value={value}
       placeholder={placeholder}
       onChange={onChange}
-      spellCheck={false}
+      spellCheck={spellCheck}
     />
   );
 };

--- a/src/app/components/Input/PasswordInput.test.tsx
+++ b/src/app/components/Input/PasswordInput.test.tsx
@@ -1,0 +1,46 @@
+// PasswordInput.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import PasswordInput from './PasswordInput';
+
+// 아이콘 모킹
+jest.mock('./../../../../public/icons', () => ({
+  IconVisivilityOff: () => <div data-testid='icon-visibility-off' />,
+  IconVisivilityOn: () => <div data-testid='icon-visibility-on' />,
+}));
+
+describe('PasswordInput', () => {
+  it('기본 렌더링', () => {
+    render(<PasswordInput aria-label='PasswordInput' />);
+
+    // 입력창이 렌더링 되었는지 확인
+    const inputElement = screen.getByLabelText('PasswordInput');
+    expect(inputElement).toBeInTheDocument();
+
+    // 가시성 토글 버튼이 렌더링 되었는지 확인
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+
+    // 비밀번호 아이콘이 렌더링 되었는지 확인
+    const icon = screen.getByTestId('icon-visibility-off');
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('버튼 클릭 시 입력 타입이 변경되는지 확인', () => {
+    render(<PasswordInput aria-label='PasswordInput' />);
+
+    // 초기 입력 타입이 'password'인지 확인
+    const inputElement = screen.getByLabelText('PasswordInput');
+    expect(inputElement).toHaveAttribute('type', 'password');
+
+    // 버튼 클릭
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    // 클릭 후 입력 타입이 'text'로 변경되었는지 확인
+    expect(inputElement).toHaveAttribute('type', 'text');
+
+    // 버튼 클릭 후 아이콘이 변경되었는지 확인
+    const icon = screen.getByTestId('icon-visibility-on');
+    expect(icon).toBeInTheDocument();
+  });
+});

--- a/src/app/components/Input/PasswordInput.test.tsx
+++ b/src/app/components/Input/PasswordInput.test.tsx
@@ -4,7 +4,7 @@ import PasswordInput from './PasswordInput';
 import '@testing-library/jest-dom';
 
 // 아이콘 모킹
-jest.mock('./../../../../public/icons', () => ({
+jest.mock('@/public/icons', () => ({
   IconVisivilityOff: () => <div data-testid='icon-visibility-off' />,
   IconVisivilityOn: () => <div data-testid='icon-visibility-on' />,
 }));

--- a/src/app/components/Input/PasswordInput.test.tsx
+++ b/src/app/components/Input/PasswordInput.test.tsx
@@ -1,6 +1,7 @@
 // PasswordInput.test.tsx
 import { render, screen, fireEvent } from '@testing-library/react';
 import PasswordInput from './PasswordInput';
+import '@testing-library/jest-dom';
 
 // 아이콘 모킹
 jest.mock('./../../../../public/icons', () => ({

--- a/src/app/components/Input/PasswordInput.test.tsx
+++ b/src/app/components/Input/PasswordInput.test.tsx
@@ -10,7 +10,8 @@ jest.mock('@/public/icons', () => ({
 }));
 
 describe('PasswordInput', () => {
-  it('기본 렌더링', () => {
+  /* 기본 렌더링 */
+  it('renders correctly', () => {
     render(<PasswordInput aria-label='PasswordInput' />);
 
     // 입력창이 렌더링 되었는지 확인
@@ -26,7 +27,8 @@ describe('PasswordInput', () => {
     expect(icon).toBeInTheDocument();
   });
 
-  it('버튼 클릭 시 입력 타입이 변경되는지 확인', () => {
+  /* 버튼 클릭 시 입력 타입이 변경되는지 확인 */
+  it('changes input type on button click', () => {
     render(<PasswordInput aria-label='PasswordInput' />);
 
     // 초기 입력 타입이 'password'인지 확인

--- a/src/app/components/Input/PasswordInput.tsx
+++ b/src/app/components/Input/PasswordInput.tsx
@@ -27,14 +27,14 @@ type PasswordType = 'password' | 'text';
  */
 const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
   ({ hasError = false, type = 'password', ...rest }, ref) => {
-    const [inputype, setInputType] = useState<PasswordType>('password');
+    const [inpuType, setInputType] = useState<PasswordType>('password');
 
     return (
       <div className='relative'>
         <Input
           hasError={hasError}
           ref={ref}
-          type={type}
+          type={inpuType}
           maxLength={16}
           {...rest}
         />
@@ -48,7 +48,11 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
           tabIndex={-1}
         >
           <div className='absolute right-16 top-1/2 size-24 -translate-y-1/2'>
-            {type === 'password' ? <IconVisivilityOff /> : <IconVisivilityOn />}
+            {inpuType === 'password' ? (
+              <IconVisivilityOff />
+            ) : (
+              <IconVisivilityOn />
+            )}
           </div>
         </button>
       </div>

--- a/src/app/components/Input/PasswordInput.tsx
+++ b/src/app/components/Input/PasswordInput.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import {
-  IconVisivilityOff,
-  IconVisivilityOn,
-} from './../../../../public/icons';
+import { IconVisivilityOff, IconVisivilityOn } from '@/public/icons';
 import Input from './Input';
 import { forwardRef, useState, InputHTMLAttributes } from 'react';
 

--- a/src/app/components/Input/PasswordInput.tsx
+++ b/src/app/components/Input/PasswordInput.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { IconVisivilityOff, IconVisivilityOn } from '@/public/icons';
+import {
+  IconVisivilityOff,
+  IconVisivilityOn,
+} from './../../../../public/icons';
 import Input from './Input';
 import { forwardRef, useState, InputHTMLAttributes } from 'react';
 
 interface PasswordInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  type?: 'text' | 'password';
   hasError?: boolean;
 }
 
@@ -22,8 +26,8 @@ type PasswordType = 'password' | 'text';
  * @param {Ref<HTMLInputElement>} ref - forwardRef를 사용하여 전달받은 ref
  */
 const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
-  ({ hasError = false, ...rest }, ref) => {
-    const [type, setType] = useState<PasswordType>('password');
+  ({ hasError = false, type = 'password', ...rest }, ref) => {
+    const [inputype, setInputType] = useState<PasswordType>('password');
 
     return (
       <div className='relative'>
@@ -37,7 +41,7 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
         <button
           type='button'
           onClick={() => {
-            setType((prevType) =>
+            setInputType((prevType) =>
               prevType === 'password' ? 'text' : 'password',
             );
           }}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "paths": {
-      "@/*": ["./src/*"],
-      "@/public/*": ["./public/*"]
+      "@/public/*": ["./public/*"],
+      "@/*": ["./src/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## ✏️ 작업 내용

- input 컴포넌트
- input-text 컴포넌트
- password input 컴포넌트

## 📷 스크린샷

## ✍️ 사용법

### input 컴포넌트
- [x] 기본 렌더링
- [x] 플레이스홀더 텍스트가 제대로 표시된다
- [x] 입력 값이 올바르게 설정된다
- [x] type 속성이 제대로 설정된다
- [x] hasError prop이 true일 때 에러 스타일이 적용된다
- [x] className prop이 적용된다
- [x] hasError prop 과, className prop 이 동시에 적용될 때도 둘 다 적용된다.
- [x] ref가 적용된다.

### input-text 컴포넌트

- [x] 기본 렌더링
- [x] 플레이스홀더 텍스트가 제대로 표시된다
- [x] 입력 값이 올바르게 설정된다
- [x] className prop이 적용된다
- [x] onChange 핸들러가 호출된다
- [x] spellCheck가 적용된다.

### password input 컴포넌트


- [x] 기본 렌더링
- [x] 버튼 클릭 시 입력 타입이 변경되는지 확인

## 🎸 기타
