### PR TITLE
test: Pagination UI 테스트 코드 작성

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,14 @@ const config = {
   testEnvironment: 'jsdom',
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  rootDir: './',
+  moduleNameMapper: {
+    '^@/public/(.*)$': '<rootDir>/public/$1', // public 폴더 매핑
+    '^@/(.*)$': '<rootDir>/src/$1', // src 폴더 매핑
+  },
+  modulePaths: ['<rootDir>'],
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json', 'node'],
+  moduleDirectories: ['node_modules', '<rootDir>'],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/src/app/(main)/gatherings/mockData/mockData.ts
+++ b/src/app/(main)/gatherings/mockData/mockData.ts
@@ -88,179 +88,24 @@ export const MOCKUSER = {
 export const DESCRIPTION =
   '따듯하게 느껴지는 공간이에요 :) 평소에 달램 이용해보고 싶었는데 이렇게 같이 달램 생기니까 너무 좋아요! 프로그램이 더 많이 늘어났으면 좋겠어요.';
 
+const generateReviews = (rating: number, count: number) => {
+  return Array.from({ length: count }, () => ({
+    rating,
+    description: DESCRIPTION,
+    user_name: '럽윈즈올',
+    date: '2024.01.25',
+  }));
+};
+
 export const MOCK_REVIEWS = [
-  {
-    rating: 1,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 1,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 1,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 1,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 2,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 2,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 2,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 2,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 3,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 3,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 3,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 3,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 4,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 4,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 4,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 4,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 5,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 5,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 5,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 5,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 4,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 4,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 4,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 4,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 3,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 3,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 3,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 3,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
-  {
-    rating: 2,
-    description: DESCRIPTION,
-    user_name: '럽윈즈올',
-    date: '2024.01.25',
-  },
+  ...generateReviews(1, 4),
+  ...generateReviews(2, 4),
+  ...generateReviews(3, 4),
+  ...generateReviews(4, 4),
+  ...generateReviews(5, 4),
+  ...generateReviews(4, 4),
+  ...generateReviews(3, 4),
+  ...generateReviews(2, 4),
+  ...generateReviews(1, 4),
+  ...generateReviews(1, 4),
 ];

--- a/src/app/components/Pagination/Pagination.test.tsx
+++ b/src/app/components/Pagination/Pagination.test.tsx
@@ -1,107 +1,154 @@
-import { render, screen, fireEvent } from '@testing-library/react';
 import Pagination from './Pagination';
 
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
+// icon mocking
+jest.mock('@/public/icons', () => ({
+  IconChevronLeft: () => <div data-testid='IconChevronLeft' />,
+  IconChevronRight: () => <div data-testid='IconChevronRight' />,
+}));
+
 describe('Pagination Component', () => {
-  const mockOnPageChange = jest.fn();
+  // 렌더링 시 이전 페이지 버튼과 다음 페이지 버튼이 표시되는지 확인
+  it('should display the previous and next page buttons when rendered', () => {
+    render(
+      <Pagination currentPage={1} totalPages={5} onPageChange={() => {}} />,
+    );
 
-  beforeEach(() => {
-    jest.clearAllMocks();
+    expect(screen.getByTestId('IconChevronLeft')).toBeInTheDocument();
+    expect(screen.getByTestId('IconChevronRight')).toBeInTheDocument();
   });
 
-  it('should render correctly with no ellipsis if total pages are less than or equal to max pages to show', () => {
+  // 현재 페이지가 1일 때 이전 페이지 버튼이 비활성화되는지 확인
+  it('should disable the previous page button when the current page is 1', () => {
     render(
-      <Pagination
-        currentPage={1}
-        totalPages={5}
-        onPageChange={mockOnPageChange}
-      />,
+      <Pagination currentPage={1} totalPages={5} onPageChange={() => {}} />,
     );
-    expect(screen.getByText('1')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
-    expect(screen.getByText('3')).toBeInTheDocument();
-    expect(screen.getByText('4')).toBeInTheDocument();
-    expect(screen.getByText('5')).toBeInTheDocument();
+
+    const prevButton = screen.getByTestId('IconChevronLeft').parentElement;
+
+    expect(prevButton).toBeDisabled();
   });
 
-  it('should render ellipsis when there are more pages than the max pages to show and the current page is near the start', () => {
+  // 현재 페이지가 마지막 페이지일 때 다음 페이지 버튼이 비활성화되는지 확인
+  it('should disable the next page button when the current page is the last page', () => {
     render(
-      <Pagination
-        currentPage={3}
-        totalPages={8}
-        onPageChange={mockOnPageChange}
-      />,
+      <Pagination currentPage={5} totalPages={5} onPageChange={() => {}} />,
     );
-    expect(screen.getByText('1')).toBeInTheDocument();
-    expect(screen.getByText('···')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
-    expect(screen.getByText('3')).toBeInTheDocument();
-    expect(screen.getByText('4')).toBeInTheDocument();
-    expect(screen.getByText('8')).toBeInTheDocument();
+
+    const nextButton = screen.getByTestId('IconChevronRight').parentElement;
+
+    expect(nextButton).toBeDisabled();
   });
 
-  it('should render ellipsis when there are more pages than the max pages to show and the current page is near the end', () => {
+  // 페이지 버튼 클릭 시 onPageChange 콜백이 호출되는지 확인
+  it('should call onPageChange when a page button is clicked', () => {
+    const onPageChange = jest.fn();
     render(
-      <Pagination
-        currentPage={6}
-        totalPages={10}
-        onPageChange={mockOnPageChange}
-      />,
+      <Pagination currentPage={2} totalPages={5} onPageChange={onPageChange} />,
     );
-    expect(screen.getByText('1')).toBeInTheDocument();
-    expect(screen.getByText('···')).toBeInTheDocument();
-    expect(screen.getByText('5')).toBeInTheDocument();
-    expect(screen.getByText('6')).toBeInTheDocument();
-    expect(screen.getByText('7')).toBeInTheDocument();
-    expect(screen.getByText('10')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('3'));
+    expect(onPageChange).toHaveBeenCalledWith(3);
   });
 
-  it('should render ellipsis when there are more pages than the max pages to show and the current page is in the middle', () => {
+  // 이전 페이지 버튼 클릭 시 onPageChange 콜백이 올바르게 호출되는지 확인
+  it('should call onPageChange correctly when the previous page button is clicked', () => {
+    const onPageChange = jest.fn();
     render(
-      <Pagination
-        currentPage={4}
-        totalPages={10}
-        onPageChange={mockOnPageChange}
-      />,
+      <Pagination currentPage={3} totalPages={5} onPageChange={onPageChange} />,
     );
-    expect(screen.getByText('1')).toBeInTheDocument();
-    expect(screen.getByText('···')).toBeInTheDocument();
-    expect(screen.getByText('3')).toBeInTheDocument();
-    expect(screen.getByText('4')).toBeInTheDocument();
-    expect(screen.getByText('5')).toBeInTheDocument();
-    expect(screen.getByText('10')).toBeInTheDocument();
+
+    const prevButton = screen.getByTestId('IconChevronLeft').parentElement;
+
+    if (prevButton) {
+      fireEvent.click(prevButton);
+    }
+
+    expect(onPageChange).toHaveBeenCalledWith(2);
   });
 
-  it('should call onPageChange with the correct page number when a page button is clicked', () => {
+  // 다음 페이지 버튼 클릭 시 onPageChange 콜백이 올바르게 호출되는지 확인
+  it('should call onPageChange correctly when the next page button is clicked', () => {
+    const onPageChange = jest.fn();
     render(
-      <Pagination
-        currentPage={1}
-        totalPages={5}
-        onPageChange={mockOnPageChange}
-      />,
+      <Pagination currentPage={3} totalPages={5} onPageChange={onPageChange} />,
     );
-    fireEvent.click(screen.getByText('2'));
-    expect(mockOnPageChange).toHaveBeenCalledWith(2);
+
+    const nextButton = screen.getByTestId('IconChevronRight').parentElement;
+
+    if (nextButton) {
+      fireEvent.click(nextButton);
+    }
+
+    expect(onPageChange).toHaveBeenCalledWith(4);
   });
 
-  it('should disable previous button on the first page and next button on the last page', () => {
+  // 현재 페이지가 4일 때 페이지네이션 범위가 올바르게 설정되는지 확인
+  it('should set the pagination range correctly when the current page is 4', () => {
     render(
-      <Pagination
-        currentPage={1}
-        totalPages={5}
-        onPageChange={mockOnPageChange}
-      />,
+      <Pagination currentPage={4} totalPages={8} onPageChange={() => {}} />,
     );
-    expect(screen.getByText('‹')).toBeDisabled();
 
+    expect(screen.getByTestId('page-button-1')).toBeInTheDocument();
+    expect(screen.getAllByText('···')).toHaveLength(2);
+    expect(screen.getByTestId('page-button-3')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-4')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-5')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-8')).toBeInTheDocument();
+  });
+
+  // 현재 페이지가 시작 부분에 가까운 경우 페이지네이션 범위가 올바르게 설정되는지 확인
+  it('should set the pagination range correctly when the current page is near the start', () => {
     render(
-      <Pagination
-        currentPage={5}
-        totalPages={5}
-        onPageChange={mockOnPageChange}
-      />,
+      <Pagination currentPage={2} totalPages={8} onPageChange={() => {}} />,
     );
-    expect(screen.getByText('›')).toBeDisabled();
+
+    expect(screen.getByTestId('page-button-1')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-2')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-3')).toBeInTheDocument();
+    expect(screen.getAllByText('···')).toHaveLength(1);
+    expect(screen.getByTestId('page-button-8')).toBeInTheDocument();
+  });
+
+  // 현재 페이지가 끝 부분에 가까운 경우 페이지네이션 범위가 올바르게 설정되는지 확인
+  it('should set the pagination range correctly when the current page is near the end', () => {
+    render(
+      <Pagination currentPage={7} totalPages={8} onPageChange={() => {}} />,
+    );
+
+    expect(screen.getByTestId('page-button-1')).toBeInTheDocument();
+    expect(screen.getAllByText('···')).toHaveLength(1);
+    expect(screen.getByTestId('page-button-6')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-7')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-8')).toBeInTheDocument();
+  });
+
+  // totalPages가 10일 때 현재 페이지가 5일 경우 페이지네이션 범위가 올바르게 설정되는지 확인
+  it('should set the pagination range correctly when totalPages is 10 and the current page is 5', () => {
+    render(
+      <Pagination currentPage={5} totalPages={10} onPageChange={() => {}} />,
+    );
+
+    expect(screen.getByTestId('page-button-1')).toBeInTheDocument();
+    expect(screen.getAllByText('···')).toHaveLength(2);
+    expect(screen.getByTestId('page-button-4')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-5')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-6')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-10')).toBeInTheDocument();
+  });
+
+  // totalPages가 10일 때 현재 페이지가 2일 경우 페이지네이션 범위가 올바르게 설정되는지 확인
+  it('should set the pagination range correctly when totalPages is 10 and the current page is 2', () => {
+    render(
+      <Pagination currentPage={2} totalPages={10} onPageChange={() => {}} />,
+    );
+
+    expect(screen.getByTestId('page-button-1')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-2')).toBeInTheDocument();
+    expect(screen.getByTestId('page-button-3')).toBeInTheDocument();
+    expect(screen.getAllByText('···')).toHaveLength(1);
+    expect(screen.getByTestId('page-button-10')).toBeInTheDocument();
   });
 });

--- a/src/app/components/Pagination/Pagination.test.tsx
+++ b/src/app/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Pagination from './Pagination';
+
+import '@testing-library/jest-dom';
+
+describe('Pagination Component', () => {
+  const mockOnPageChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render correctly with no ellipsis if total pages are less than or equal to max pages to show', () => {
+    render(
+      <Pagination
+        currentPage={1}
+        totalPages={5}
+        onPageChange={mockOnPageChange}
+      />,
+    );
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('should render ellipsis when there are more pages than the max pages to show and the current page is near the start', () => {
+    render(
+      <Pagination
+        currentPage={3}
+        totalPages={8}
+        onPageChange={mockOnPageChange}
+      />,
+    );
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('···')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+
+  it('should render ellipsis when there are more pages than the max pages to show and the current page is near the end', () => {
+    render(
+      <Pagination
+        currentPage={6}
+        totalPages={10}
+        onPageChange={mockOnPageChange}
+      />,
+    );
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('···')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('6')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+
+  it('should render ellipsis when there are more pages than the max pages to show and the current page is in the middle', () => {
+    render(
+      <Pagination
+        currentPage={4}
+        totalPages={10}
+        onPageChange={mockOnPageChange}
+      />,
+    );
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('···')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+
+  it('should call onPageChange with the correct page number when a page button is clicked', () => {
+    render(
+      <Pagination
+        currentPage={1}
+        totalPages={5}
+        onPageChange={mockOnPageChange}
+      />,
+    );
+    fireEvent.click(screen.getByText('2'));
+    expect(mockOnPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it('should disable previous button on the first page and next button on the last page', () => {
+    render(
+      <Pagination
+        currentPage={1}
+        totalPages={5}
+        onPageChange={mockOnPageChange}
+      />,
+    );
+    expect(screen.getByText('‹')).toBeDisabled();
+
+    render(
+      <Pagination
+        currentPage={5}
+        totalPages={5}
+        onPageChange={mockOnPageChange}
+      />,
+    );
+    expect(screen.getByText('›')).toBeDisabled();
+  });
+});

--- a/src/app/components/Pagination/Pagination.test.tsx
+++ b/src/app/components/Pagination/Pagination.test.tsx
@@ -5,8 +5,12 @@ import '@testing-library/jest-dom';
 
 // icon mocking
 jest.mock('@/public/icons', () => ({
-  IconChevronLeft: () => <div data-testid='IconChevronLeft' />,
-  IconChevronRight: () => <div data-testid='IconChevronRight' />,
+  IconChevronLeft: ({ onClick }: { onClick?: () => void }) => (
+    <div data-testid='IconChevronLeft' onClick={onClick} />
+  ),
+  IconChevronRight: ({ onClick }: { onClick?: () => void }) => (
+    <div data-testid='IconChevronRight' onClick={onClick} />
+  ),
 }));
 
 describe('Pagination Component', () => {
@@ -60,12 +64,9 @@ describe('Pagination Component', () => {
       <Pagination currentPage={3} totalPages={5} onPageChange={onPageChange} />,
     );
 
-    const prevButton = screen.getByTestId('IconChevronLeft').parentElement;
+    const prevButton = screen.getByTestId('IconChevronLeft');
 
-    if (prevButton) {
-      fireEvent.click(prevButton);
-    }
-
+    fireEvent.click(prevButton);
     expect(onPageChange).toHaveBeenCalledWith(2);
   });
 
@@ -76,12 +77,9 @@ describe('Pagination Component', () => {
       <Pagination currentPage={3} totalPages={5} onPageChange={onPageChange} />,
     );
 
-    const nextButton = screen.getByTestId('IconChevronRight').parentElement;
+    const nextButton = screen.getByTestId('IconChevronRight');
 
-    if (nextButton) {
-      fireEvent.click(nextButton);
-    }
-
+    fireEvent.click(nextButton);
     expect(onPageChange).toHaveBeenCalledWith(4);
   });
 

--- a/src/app/components/Pagination/Pagination.tsx
+++ b/src/app/components/Pagination/Pagination.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-
 import { IconChevronLeft, IconChevronRight } from '@/public/icons';
 
 const MAX_PAGES_TO_SHOW_TABLET = 4; // 태블릿에서 표시할 최대 페이지 수
@@ -44,29 +43,29 @@ const Pagination = ({
   // 페이지네이션 범위 설정 함수
   const getPaginationRange = () => {
     const range: (number | string)[] = [];
-
     const maxPagesToShow = isTablet
       ? MAX_PAGES_TO_SHOW_TABLET
       : MAX_PAGES_TO_SHOW_DESKTOP;
 
-    // 총 페이지 수가 maxPages 보다 작은 경우
+    // 총 페이지 수가 maxPagesToShow보다 적은 경우
     if (totalPages <= maxPagesToShow) {
       for (let i = 1; i <= totalPages; i++) {
         range.push(i);
       }
     } else {
-      // 현재 페이지가 처음 부분에 가까운 경우
-      if (currentPage <= Math.floor(maxPagesToShow / 2) + 1) {
+      // 중간값 판별을 위한 변수
+      const half = Math.floor(maxPagesToShow / 2);
+
+      // 현재 페이지가 시작 부분에 가까운 경우
+      if (currentPage <= half) {
         for (let i = 1; i <= maxPagesToShow - 1; i++) {
           range.push(i);
         }
-
         range.push('···', totalPages);
       }
-      // 현재 페이지가 마지막 부분에 가까운 경우
-      else if (currentPage >= totalPages - Math.floor(maxPagesToShow / 2)) {
+      // 현재 페이지가 끝 부분에 가까운 경우
+      else if (currentPage >= totalPages - half) {
         range.push(1, '···');
-
         for (let i = totalPages - (maxPagesToShow - 2); i <= totalPages; i++) {
           range.push(i);
         }
@@ -77,8 +76,7 @@ const Pagination = ({
         for (let i = currentPage - 1; i <= currentPage + 1; i++) {
           range.push(i);
         }
-
-        range.push(totalPages);
+        range.push('···', totalPages);
       }
     }
 

--- a/src/app/components/Pagination/Pagination.tsx
+++ b/src/app/components/Pagination/Pagination.tsx
@@ -74,7 +74,9 @@ const Pagination = ({
       else {
         range.push(1, '···');
         for (let i = currentPage - 1; i <= currentPage + 1; i++) {
-          range.push(i);
+          if (i > 1 && i < totalPages) {
+            range.push(i);
+          }
         }
         range.push('···', totalPages);
       }
@@ -101,6 +103,7 @@ const Pagination = ({
         typeof item === 'number' ? (
           <button
             key={item}
+            data-testid={`page-button-${item}`}
             className={`rounded-lg border p-[10px] ${
               currentPage === item
                 ? 'text-16 font-semibold text-var-black'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "paths": {
-      "@/*": ["./src/*"],
-      "@/public/*": ["./public/*"]
+      "@/public/*": ["./public/*"],
+      "@/*": ["./src/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## ✏️ 작업 내용

- Pagination UI 테스트 코드 작성

## 📷 스크린샷

## ✍️ 사용법

- [x] 렌더링 시 이전 페이지 버튼과 다음 페이지 버튼이 표시되는지 확인
- [x] 현재 페이지가 1일 때 이전 페이지 버튼이 비활성화되는지 확인
- [x] 현재 페이지가 마지막 페이지일 때 다음 페이지 버튼이 비활성화되는지 확인
- [x] 페이지 버튼 클릭 시 onPageChange 콜백이 호출되는지 확인
- [x] 이전 페이지 버튼 클릭 시 onPageChange 콜백이 올바르게 호출되는지 확인
- [x] 다음 페이지 버튼 클릭 시 onPageChange 콜백이 올바르게 호출되는지 확인
- [x] 현재 페이지가 4일 때 페이지네이션 범위가 올바르게 설정되는지 확인
- [x] 현재 페이지가 시작 부분에 가까운 경우 페이지네이션 범위가 올바르게 설정되는지 확인
- [x] 현재 페이지가 끝 부분에 가까운 경우 페이지네이션 범위가 올바르게 설정되는지 확인
- [x] totalPages가 10일 때 현재 페이지가 5일 경우 페이지네이션 범위가 올바르게 설정되는지 확인
- [x] totalPages가 10일 때 현재 페이지가 2일 경우 페이지네이션 범위가 올바르게 설정되는지 확인

## 🎸 기타

### Pagination 컴포넌트 변경

totalPages 가 커졌을 때 논리 오류가 발생했습니다.

따라서 관련 로직을 수정하였습니다.

확인 부탁드립니다.
