### PR TITLE
test : Filter 컴포넌트 테스트 코드 작성

### DIFF
--- a/src/app/components/Filter/FilterDate.tsx
+++ b/src/app/components/Filter/FilterDate.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from 'react';
+import { IconCaret } from '@/public/icons';
+import CalendarModal from '../Modal/CalendarModal';
+
+const stateClasses = {
+  default: 'border border-var-gray-100 bg-var-gray-50 text-var-gray-800',
+  active: 'text-var-gray-50 bg-var-gray-900',
+};
+
+interface FilterDateProps {
+  state?: 'default' | 'active';
+  children: string;
+}
+
+const FilterDate = ({ state = 'default', children }: FilterDateProps) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [currentState, setCurrentState] = useState<'default' | 'active'>(state);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // TODO : 적용 버튼 클릭 시 핸들러를 CalendarModal로 전달
+  const handleDateSelect = (date: string) => {
+    setSelectedDate(date);
+    setIsOpen(false);
+    setCurrentState('active');
+  };
+
+  // TODO : 초기화 버튼 클릭 시 핸들러를 CalendarModal로 전달
+  const handleDateReset = () => {
+    setSelectedDate(null);
+    setIsOpen(false);
+    setCurrentState('default');
+  };
+
+  const toggleDropDown = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  // 외부 클릭 시 드롭다운 닫힘
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div className='relative' ref={containerRef}>
+      <div
+        className={`flex h-36 w-[110px] cursor-pointer items-center justify-between rounded-[12px] py-[6px] pl-12 pr-8 text-14 font-medium md:h-40 md:w-120 md:py-8 ${stateClasses[currentState]}`}
+        onClick={toggleDropDown}
+        data-testid='filterList'
+      >
+        {selectedDate || children}
+        <IconCaret className='h-24 w-24' />
+      </div>
+
+      {isOpen && (
+        <div
+          className={`absolute z-10 mt-4 h-auto w-full min-w-max overflow-y-auto rounded-xl bg-var-gray-50 ring-2 ring-var-gray-400`}
+        >
+          <CalendarModal />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FilterDate;

--- a/src/app/components/Filter/FilterList.test.tsx
+++ b/src/app/components/Filter/FilterList.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FilterList from './FilterList';
+
+// 아이콘 모킹
+jest.mock('@/public/icons', () => ({
+  IconCaret: () => <div data-testid='IconCaret' />,
+}));
+
+describe('FilterList Component', () => {
+  const defaultProps = {
+    children: 'Filter',
+    options: ['Option 1', 'Option 2', 'Option 3'],
+  };
+
+  beforeEach(() => {
+    render(<FilterList {...defaultProps} />);
+  });
+
+  it('should render FilterList component', () => {
+    const filterElement = screen.getByTestId('filterList');
+    expect(filterElement).toBeInTheDocument();
+    expect(filterElement).toHaveTextContent('Filter');
+  });
+
+  it('should render options when clicked FilterList componenet', () => {
+    const filterElement = screen.getByTestId('filterList');
+    fireEvent.click(filterElement);
+
+    defaultProps.options.forEach((option) => {
+      const optionElement = screen.getByText(option);
+      expect(optionElement).toBeInTheDocument();
+    });
+  });
+
+  it.each(defaultProps.options)(
+    'should change TextContent to `%s` when %s is clicked',
+    (option) => {
+      const filterElement = screen.getByTestId('filterList');
+      fireEvent.click(filterElement);
+
+      const optionElement = screen.getByText(option);
+      fireEvent.click(optionElement);
+
+      expect(filterElement).toHaveTextContent(option);
+    },
+  );
+
+  // 기본 필터 선택 시 초기화 테스트
+  it('resets to default option', () => {
+    const filterElement = screen.getByTestId('filterList');
+    fireEvent.click(filterElement);
+
+    const optionElement = screen.getByText('Option 1');
+    fireEvent.click(optionElement);
+
+    fireEvent.click(filterElement);
+    const defaultOptionElement = screen.getByText('Filter');
+    fireEvent.click(defaultOptionElement);
+
+    expect(filterElement).toHaveTextContent('Filter');
+  });
+});

--- a/src/app/components/Filter/FilterList.test.tsx
+++ b/src/app/components/Filter/FilterList.test.tsx
@@ -44,6 +44,7 @@ describe('FilterList Component', () => {
       fireEvent.click(optionElement);
 
       expect(filterElement).toHaveTextContent(option);
+      expect(filterElement).toHaveClass('text-var-gray-50 bg-var-gray-900');
     },
   );
 
@@ -60,5 +61,6 @@ describe('FilterList Component', () => {
     fireEvent.click(defaultOptionElement);
 
     expect(filterElement).toHaveTextContent('Filter');
+    expect(filterElement).toHaveClass('bg-var-gray-50 text-var-gray-800');
   });
 });

--- a/src/app/components/Filter/FilterList.tsx
+++ b/src/app/components/Filter/FilterList.tsx
@@ -65,6 +65,7 @@ const FilterList = ({
       <div
         className={`flex h-36 w-[110px] cursor-pointer items-center justify-between rounded-[12px] py-[6px] pl-12 pr-8 text-14 font-medium md:h-40 md:w-120 md:py-8 ${stateClasses[currentState]}`}
         onClick={toggleDropDown}
+        data-testid='filterList'
       >
         {selectedOption || children}
         <IconCaret className='h-24 w-24' />


### PR DESCRIPTION
## ✏️ 작업 내용

- FilterList 컴포넌트 테스트 코드 작성
- FilterDate 컴포넌트 추가 

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/f10f238d-3009-45ac-a0eb-a40c911065a9)

## ✍️ 사용법
```ts
<FilterDate state='default'>날짜 선택</FilterDate>
```

## 🎸 기타

### Filter 컴포넌트 수정안
기존 Filter 컴포넌트를 최초 Input 형태의 style로 판단하여, FilterList 와 FilterSort 두 가지 종류로 나누었습니다.
다만 Test 코드를 작성하면서, 형태는 FilterList와 Sort가 동일하며, 날짜 선택 경우를 추가할 필요성을 느꼈습니다.
이로 인해 **FilterDate 컴포넌트 코드를 추가로 작성**하였고, (캘린더 컴포넌트에서 수정 필요)
기존의 **FilterList와 FilterSort를 하나의 컴포넌트로 통합** 및 type props를 추가하여 style만 변경되도록 하는 방안을 제시 드립니다.

### Test Case

- [x] 최초 렌더링 시, children 텍스트를 출력하는지
- [x] 컴포넌트 클릭 시 options 텍스트를 전부 출력하는지 
- [x] option 을 클릭 시 해당 텍스트로 변경 및 style이 변경되는지(active state)
- [x] 기본 필터(children) 선택 시 텍스트 및 style이 초기화 되는지 

### FilterDate
현재는 컴포넌트의 외관 및 클릭 시 드롭다운으로 DatePicker가 나타나게 되어 있습니다.
날짜 적용 및 초기화 시 해당 date 정보를 저장하거나, 컴포넌트의 state가 active로 변하는 등의 추가 작업이 필요합니다.

close #53