### PR TITLE
feat: 마이페이지 - 내가 만든 모임 페이지 UI

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -8,7 +8,7 @@ const Layout = ({
   children: ReactNode;
 }>) => {
   return (
-    <div className='min-h-dvh w-full bg-var-gray-100'>
+    <div className='flex h-full w-full items-center justify-center bg-var-gray-100'>
       <div className='flex flex-col items-center justify-between gap-32 py-40 md:mx-24 lg:mx-auto lg:max-w-[1200px] lg:flex-row lg:gap-100 lg:px-24 lg:pt-40'>
         {/* 이미지 영역 */}
         <div className='text-center'>

--- a/src/app/(main)/mypage/_component/Tab.tsx
+++ b/src/app/(main)/mypage/_component/Tab.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const tabList = [
+  {
+    name: '나의 모임',
+    link: '/mypage/myGetherings',
+  },
+  {
+    name: '나의 리뷰',
+    link: '/mypage/myReview',
+  },
+  {
+    name: '내가 만든 모임',
+    link: '/mypage/created',
+  },
+];
+
+const Tab = () => {
+  const pathname = usePathname();
+
+  const activeClass = 'border-b-2 border-var-gray-900 pb-4 text-var-gray-900';
+
+  return (
+    <ul className='flex items-start gap-12 text-18 font-semibold text-var-gray-400'>
+      {tabList.map((item, index) => (
+        <li key={index} className={pathname === item.link ? activeClass : ''}>
+          <Link href={item.link}>{item.name}</Link>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default Tab;

--- a/src/app/(main)/mypage/created/mockData.ts
+++ b/src/app/(main)/mypage/created/mockData.ts
@@ -1,0 +1,74 @@
+import { UserJoinedGatheringsData } from '@/types/data.type';
+
+export const tomorrow = new Date();
+tomorrow.setDate(tomorrow.getDate() + 1);
+
+export const registrationEnd = new Date(tomorrow);
+registrationEnd.setDate(tomorrow.getDate() - 1);
+
+export const DATA_LIST: UserJoinedGatheringsData[] = [
+  {
+    teamId: 0,
+    id: 0,
+    type: 'dalaemfit',
+    name: '달램핏 오피스 스트레칭',
+    dateTime: tomorrow.toISOString(),
+    registrationEnd: registrationEnd.toISOString(),
+    location: '을지로 3가',
+    participantCount: 20,
+    capacity: 20,
+    image: '/images/mock-image.png',
+    createdBy: 0,
+    joinedAt: registrationEnd.toISOString(),
+    isCompleted: true,
+    isReviewed: true,
+  },
+  {
+    teamId: 0,
+    id: 1,
+    type: 'dalaemfit',
+    name: '달램핏 오피스 스트레칭',
+    dateTime: tomorrow.toISOString(),
+    registrationEnd: registrationEnd.toISOString(),
+    location: '을지로 3가',
+    participantCount: 12,
+    capacity: 20,
+    image: '/images/mock-image.png',
+    createdBy: 0,
+    joinedAt: registrationEnd.toISOString(),
+    isCompleted: true,
+    isReviewed: true,
+  },
+  {
+    teamId: 0,
+    id: 2,
+    type: 'dalaemfit',
+    name: '달램핏 오피스 스트레칭',
+    dateTime: tomorrow.toISOString(),
+    registrationEnd: registrationEnd.toISOString(),
+    location: '을지로 3가',
+    participantCount: 12,
+    capacity: 20,
+    image: '/images/mock-image.png',
+    createdBy: 0,
+    joinedAt: registrationEnd.toISOString(),
+    isCompleted: true,
+    isReviewed: true,
+  },
+  {
+    teamId: 0,
+    id: 3,
+    type: 'dalaemfit',
+    name: '달램핏 오피스 스트레칭',
+    dateTime: tomorrow.toISOString(),
+    registrationEnd: registrationEnd.toISOString(),
+    location: '을지로 3가',
+    participantCount: 12,
+    capacity: 20,
+    image: '/images/mock-image.png',
+    createdBy: 0,
+    joinedAt: registrationEnd.toISOString(),
+    isCompleted: true,
+    isReviewed: true,
+  },
+];

--- a/src/app/(main)/mypage/created/page.tsx
+++ b/src/app/(main)/mypage/created/page.tsx
@@ -1,0 +1,24 @@
+import Card from '@/app/components/Card/Card';
+import Tab from '../_component/Tab';
+import { DATA_LIST } from './mockData';
+
+const CreatedPage = () => {
+  return (
+    <section className='flex w-full grow flex-col border-t-2 border-var-gray-900 bg-white px-16 py-24 md:px-24'>
+      <Tab />
+
+      <div className='grow'>
+        {DATA_LIST.map((data) => (
+          <Card key={data.id} data={data} />
+        ))}
+      </div>
+
+      {/* 내가 만든 모임이 없을 경우 */}
+      {/* <div className='flex grow items-center justify-center text-14 font-medium text-var-gray-500'>
+        아직 만든 모임이 없어요
+      </div> */}
+    </section>
+  );
+};
+
+export default CreatedPage;

--- a/src/app/(main)/mypage/layout.tsx
+++ b/src/app/(main)/mypage/layout.tsx
@@ -1,0 +1,21 @@
+import UserProfileLayout from '@/app/components/UserProfileLayout/UserProfileLayout';
+import { ReactNode } from 'react';
+
+const Layout = ({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) => {
+  return (
+    <main className='mx-auto flex h-full max-w-1200 flex-col bg-var-gray-50 px-16 pt-24 md:px-24 md:pt-32 lg:px-100'>
+      {/* head */}
+      <div className='mb-16 flex flex-col gap-16 md:mb-28 md:gap-24'>
+        <h2 className='text-24 font-semibold text-var-gray-900'>마이페이지</h2>
+        <UserProfileLayout />
+      </div>
+      {children}
+    </main>
+  );
+};
+
+export default Layout;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
     <html lang='ko'>
       <body className='min-h-dvh bg-var-gray-100 font-pretendard'>
         <Gnb />
-        <div className='pt-60'>{children}</div>
+        <div className='h-full pt-60'>{children}</div>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,9 +17,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ko'>
-      <body className='min-h-dvh bg-var-gray-100 font-pretendard'>
+      <body className='flex min-h-dvh flex-col bg-var-gray-100 font-pretendard'>
         <Gnb />
-        <div className='h-full pt-60'>{children}</div>
+        <div className='grow pt-60'>{children}</div>
       </body>
     </html>
   );

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -8,6 +8,7 @@ html,
 body {
   font-size: 62.5%;
   -webkit-font-smoothing: antialiased;
+  height: 100%;
 }
 
 body {

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -8,6 +8,7 @@ html,
 body {
   font-size: 62.5%;
   -webkit-font-smoothing: antialiased;
+  min-height: 100%;
   height: 100%;
 }
 


### PR DESCRIPTION
## ✏️ 작업 내용
- 전체 레이아웃 style 및 auth 그룹 레이아웃의 css 수정
- 마이페이지 - 내가 만든 모임 페이지 UI

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/95b64594-5d95-44b3-bf3a-7a73d77887bb)
![image](https://github.com/user-attachments/assets/0edf8048-a036-4362-8ce7-c9aab50fd597)

데이터가 없을 경우

![image](https://github.com/user-attachments/assets/e345d049-fee4-4dd4-996c-995f778b239a)
![image](https://github.com/user-attachments/assets/5e67a0d5-34e9-4a20-a83e-859d49d52ec0)


## ✍️ 사용법

## 🎸 기타

자연스러운 페이지 구성을 위해 레이아웃의 css을 수정하였습니다.
다른 페이지에서 문제는 안 되나, (auth) 그룹에서 약간의 깨짐이 있어 (auth) 그룹 레이아웃 css를 수정하였습니다!
@hakyoung12 확인 부탁드려요..!

마이페이지 라우팅 폴더에 layout으로 프로필 부분 등을 넣어놓았습니다. 
다른분들 UI 작업 시 중복/충돌이 생긴다면 의견 부탁드려요!!

close #65