### PR TITLE
feat: 찜한 모임 페이지 API 연동

### DIFF
--- a/src/app/(main)/saved/_component/Chips.tsx
+++ b/src/app/(main)/saved/_component/Chips.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+
+import Chip from '@/app/components/Chip/Chip';
+
+interface ChipsProps {
+  activeTab: 'DALLAEMFIT' | 'WORKATION';
+  selectedChip: 'ALL' | 'OFFICE_STRETCHING' | 'MINDFULNESS';
+  onChipClick: (label: 'ALL' | 'OFFICE_STRETCHING' | 'MINDFULNESS') => void;
+}
+
+const Chips = ({ activeTab, selectedChip, onChipClick }: ChipsProps) => {
+  return (
+    <div className='mt-8 space-x-8 py-16'>
+      <Chip
+        state={selectedChip === 'ALL' ? 'active' : 'default'}
+        onClick={
+          activeTab === 'WORKATION' ? undefined : () => onChipClick('ALL')
+        }
+      >
+        전체
+      </Chip>
+      {/* activeTab이 'WORKATION'이 아닐 때만 다른 Chip을 렌더링 */}
+      {activeTab === 'DALLAEMFIT' && (
+        <>
+          <Chip
+            state={selectedChip === 'OFFICE_STRETCHING' ? 'active' : 'default'}
+            onClick={() => onChipClick('OFFICE_STRETCHING')}
+          >
+            오피스 스트레칭
+          </Chip>
+          <Chip
+            state={selectedChip === 'MINDFULNESS' ? 'active' : 'default'}
+            onClick={() => onChipClick('MINDFULNESS')}
+          >
+            마인드풀니스
+          </Chip>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default Chips;

--- a/src/app/(main)/saved/_component/Header.tsx
+++ b/src/app/(main)/saved/_component/Header.tsx
@@ -1,0 +1,19 @@
+import { HeadSaved } from '@/public/images';
+
+const Header = () => {
+  return (
+    <div className='flex items-center gap-16'>
+      <HeadSaved className='size-72' />
+      <div>
+        <h2 className='mb-8 text-18 font-semibold text-var-gray-900'>
+          찜한 모임
+        </h2>
+        <p className='text-14 font-medium text-var-gray-700'>
+          마감되기 전에 지금 바로 참여해보세요 👀
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Header;

--- a/src/app/(main)/saved/_component/SavedList.tsx
+++ b/src/app/(main)/saved/_component/SavedList.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import CardList from '@/app/components/CardList/CardList';
+import { useSavedGatheringList } from '@/context/SavedGatheringContext';
+import { GatheringsListData } from '@/types/data.type';
+
+interface SavedListProps {
+  dataList: GatheringsListData[];
+}
+
+const SavedList = ({ dataList }: SavedListProps) => {
+  const { savedGatherings, updateGathering } = useSavedGatheringList();
+
+  const isSaved = (id: number) => savedGatherings.includes(id);
+
+  const handleButtonClick = (id: number) => {
+    updateGathering(id);
+  };
+
+  return (
+    <>
+      {dataList.map((item) => (
+        <CardList
+          key={item.id}
+          data={item}
+          isSaved={isSaved(item.id)}
+          handleButtonClick={handleButtonClick}
+        />
+      ))}
+    </>
+  );
+};
+
+export default SavedList;

--- a/src/app/(main)/saved/mockData.ts
+++ b/src/app/(main)/saved/mockData.ts
@@ -1,10 +1,12 @@
+import { GatheringsListData } from '@/types/data.type';
+
 export const tomorrow = new Date();
 tomorrow.setDate(tomorrow.getDate() + 1);
 
 export const registrationEnd = new Date(tomorrow);
 registrationEnd.setDate(tomorrow.getDate() - 1);
 
-export const DATA_LIST = [
+export const DATA_LIST: GatheringsListData[] = [
   {
     teamId: 0,
     id: 0,

--- a/src/app/(main)/saved/page.tsx
+++ b/src/app/(main)/saved/page.tsx
@@ -12,6 +12,8 @@ import { GatheringChipsType, GatheringTabsType } from '@/types/client.type';
 import SavedList from './_component/SavedList';
 
 // TODO : 페이지 단의 코드를 계층화 하여 각 컴포넌트를 분리하기 위한 리팩토링
+// TODO : 1. 필터링 상태에서 찜한 모임 삭제 시 필터링 상태 유지
+// TODO : 2. 날짜 필터링 기능 보완
 
 const sortOptionsMap: Record<string, string> = {
   최신순: 'dateTime',

--- a/src/app/(main)/saved/page.tsx
+++ b/src/app/(main)/saved/page.tsx
@@ -11,6 +11,8 @@ import { useSavedGatheringList } from '@/context/SavedGatheringContext';
 import { GatheringChipsType, GatheringTabsType } from '@/types/client.type';
 import SavedList from './_component/SavedList';
 
+// TODO : 페이지 단의 코드를 계층화 하여 각 컴포넌트를 분리하기 위한 리팩토링
+
 const sortOptionsMap: Record<string, string> = {
   최신순: 'dateTime',
   '마감 임박': 'registrationEnd',

--- a/src/app/(main)/saved/page.tsx
+++ b/src/app/(main)/saved/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { use, useEffect, useState } from 'react';
-import CardList from '@/app/components/CardList/CardList';
-import { DATA_LIST } from './mockData';
+import { useEffect, useState } from 'react';
 import Tabs from '@/app/components/Tabs/Tabs';
 import Chips from './_component/Chips';
 import Header from './_component/Header';
@@ -11,6 +9,7 @@ import getGatherings from '@/app/api/actions/gatherings/getGatherings';
 import { GatheringsListData } from '@/types/data.type';
 import { useSavedGatheringList } from '@/context/SavedGatheringContext';
 import { GatheringChipsType, GatheringTabsType } from '@/types/client.type';
+import SavedList from './_component/SavedList';
 
 const sortOptionsMap: Record<string, string> = {
   최신순: 'dateTime',
@@ -142,7 +141,7 @@ const SavedPage = () => {
         {/* data list */}
         <div className='mt-24 flex grow flex-col gap-24'>
           {filteredData.length > 0 ? (
-            filteredData.map((item) => <CardList key={item.id} data={item} />)
+            <SavedList dataList={filteredData} />
           ) : (
             <div className='flex size-full grow items-center justify-center text-14 font-medium text-var-gray-500'>
               아직 아직 찜한 모임이 없어요.

--- a/src/app/(main)/saved/page.tsx
+++ b/src/app/(main)/saved/page.tsx
@@ -1,114 +1,148 @@
 'use client';
 
-import { useState } from 'react';
-import { HeadSaved } from '@/public/images';
-import Tab from '@/app/components/Tab/Tab';
-import Chip from '@/app/components/Chip/Chip';
+import { use, useEffect, useState } from 'react';
 import CardList from '@/app/components/CardList/CardList';
-import Filter from '@/app/components/Filter/Filter';
-import FilterDate from '@/app/components/Filter/FilterDate';
-import { DATA_LIST, OPTIONS, SORT_OPTIONS } from './mockData';
+import { DATA_LIST } from './mockData';
+import Tabs from '@/app/components/Tabs/Tabs';
+import Chips from './_component/Chips';
+import Header from './_component/Header';
+import Filters from '@/app/components/Filters/Filters';
+import getGatherings from '@/app/api/actions/gatherings/getGatherings';
+import { GatheringsListData } from '@/types/data.type';
+import { useSavedGatheringList } from '@/context/SavedGatheringContext';
+import { GatheringChipsType, GatheringTabsType } from '@/types/client.type';
+
+const sortOptionsMap: Record<string, string> = {
+  최신순: 'dateTime',
+  '마감 임박': 'registrationEnd',
+  '참여 인원 순': 'participantCount',
+};
 
 const SavedPage = () => {
-  const [activeTab, setActiveTab] = useState<'dalaemfit' | 'workation'>(
-    'dalaemfit',
-  );
+  const [initialGatherings, setIinitialGatherings] = useState<
+    GatheringsListData[]
+  >([]);
+  const [filteredData, setFilteredData] =
+    useState<GatheringsListData[]>(initialGatherings);
 
-  const [activeChip, setActiveChip] = useState<
-    'all' | 'officeStretching' | 'mindfulness'
-  >('all');
+  const { savedGatherings, updateGathering } = useSavedGatheringList();
 
-  const handleClickTab = (type: 'dalaemfit' | 'workation') => {
+  const [activeTab, setActiveTab] = useState<GatheringTabsType>('DALLAEMFIT');
+  const [activeChip, setActiveChip] = useState<GatheringChipsType>('ALL');
+
+  const handleTabClick = (type: GatheringTabsType) => {
     setActiveTab(type);
-    if (type === 'workation') {
-      setActiveChip('all');
-    }
+    setActiveChip('ALL');
   };
 
-  const handleClickChips = (
-    type: 'all' | 'officeStretching' | 'mindfulness',
-  ) => {
+  const handleChipClick = (type: GatheringChipsType) => {
     setActiveChip(type);
   };
 
+  // Active Tab 이 바뀔 때마다, 해당 탭에 맞는 모임 리스트를 가져옴
+  useEffect(() => {
+    const getSavedGatherings = async () => {
+      const idString = savedGatherings.join(',');
+      const res = await getGatherings({
+        id: idString,
+        type: activeTab,
+        limit: savedGatherings.length,
+      });
+      setIinitialGatherings(res);
+      setFilteredData(res);
+    };
+
+    if (savedGatherings.length > 0) {
+      getSavedGatherings();
+    }
+  }, [savedGatherings, activeTab]);
+
+  const [selectedLocation, setSelectedLocation] = useState<string | undefined>(
+    undefined,
+  );
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [sortOption, setSortOption] = useState<string | undefined>();
+
+  const handleLocationChange = (location: string | undefined) => {
+    setSelectedLocation(location);
+  };
+
+  const handleDateChange = (date: Date | null) => {
+    setSelectedDate(date);
+  };
+
+  const handleSortChange = (option: string | undefined) => {
+    setSortOption(option);
+  };
+
+  useEffect(() => {
+    let filtered = initialGatherings;
+
+    if (activeChip !== 'ALL') {
+      filtered = initialGatherings.filter((item) => item.type === activeChip);
+    }
+
+    if (selectedLocation) {
+      filtered = filtered.filter((item) => item.location === selectedLocation);
+    }
+
+    if (selectedDate) {
+      filtered = filtered.filter(
+        (item) => item.dateTime === selectedDate.toISOString(),
+      );
+    }
+
+    if (sortOption) {
+      const sortField = sortOptionsMap[sortOption]; // sortOption에 맞는 필드를 매핑
+
+      if (sortField === 'dateTime') {
+        // 최신순: dateTime을 기준으로 최신 날짜가 앞에 오도록 정렬
+        filtered = [...filtered].sort(
+          (a, b) =>
+            new Date(b.dateTime).getTime() - new Date(a.dateTime).getTime(),
+        );
+      } else if (sortField === 'registrationEnd') {
+        // 마감 임박: registrationEnd 문자열을 Date 객체로 변환하여 가까운 마감일이 앞에 오도록 정렬
+        filtered = [...filtered].sort(
+          (a, b) =>
+            new Date(a.registrationEnd).getTime() -
+            new Date(b.registrationEnd).getTime(),
+        );
+      } else if (sortField === 'participantCount') {
+        // 참여 인원 순: participantCount가 많은 순으로 정렬
+        filtered = [...filtered].sort(
+          (a, b) => b.participantCount - a.participantCount,
+        );
+      }
+    }
+    setFilteredData(filtered);
+  }, [activeChip, selectedLocation, selectedDate, sortOption]);
+
   return (
     <main className='mx-auto flex h-full max-w-1200 flex-col bg-var-gray-50 px-16 pb-48 pt-24 md:px-24 md:pt-40 lg:px-100'>
-      {/* head */}
-      <div className='flex items-center gap-16'>
-        <HeadSaved className='size-72' />
-        <div>
-          <h2 className='mb-8 text-18 font-semibold text-var-gray-900'>
-            찜한 모임
-          </h2>
-          <p className='text-14 font-medium text-var-gray-700'>
-            마감되기 전에 지금 바로 참여해보세요 👀
-          </p>
-        </div>
-      </div>
+      <Header />
 
       <section className='mt-24 flex grow flex-col md:mt-32'>
-        {/* tab */}
-        <div className='mb-12 flex items-center'>
-          <Tab
-            type='dalaemfit'
-            isActive={activeTab === 'dalaemfit'}
-            onClick={() => handleClickTab('dalaemfit')}
+        <Tabs activeTab={activeTab} onTabClick={handleTabClick} />
+
+        <div className='flex flex-col gap-16 divide-y'>
+          <Chips
+            activeTab={activeTab}
+            selectedChip={activeChip}
+            onChipClick={handleChipClick}
           />
-          <Tab
-            type='workation'
-            isActive={activeTab === 'workation'}
-            onClick={() => handleClickTab('workation')}
+
+          <Filters
+            onLocationChange={handleLocationChange}
+            onDateChange={handleDateChange}
+            onSortChange={handleSortChange}
           />
         </div>
 
-        <div className='flex flex-col gap-16'>
-          {/* 버튼 칩 */}
-          <div
-            className={`flex items-center gap-8 ${activeTab === 'workation' && 'hidden'}`}
-          >
-            <button type='button' onClick={() => handleClickChips('all')}>
-              <Chip state={activeChip === 'all' ? 'active' : 'default'}>
-                전체
-              </Chip>
-            </button>
-            <button
-              type='button'
-              onClick={() => handleClickChips('officeStretching')}
-            >
-              <Chip
-                state={activeChip === 'officeStretching' ? 'active' : 'default'}
-              >
-                오피스 스트레칭
-              </Chip>
-            </button>
-            <button
-              type='button'
-              onClick={() => handleClickChips('mindfulness')}
-            >
-              <Chip state={activeChip === 'mindfulness' ? 'active' : 'default'}>
-                마인드풀니스
-              </Chip>
-            </button>
-          </div>
-
-          <div className='w-full border-y border-var-gray-200' />
-          {/* filter */}
-          <div className='flex items-center justify-between'>
-            <div className='flex gap-8'>
-              <Filter type='list' state='default' options={OPTIONS}>
-                지역 선택
-              </Filter>
-              <FilterDate state='default'>날짜 선택</FilterDate>
-            </div>
-            <Filter type='sort' state='default' options={SORT_OPTIONS}>
-              마감 임박
-            </Filter>
-          </div>
-        </div>
         {/* data list */}
         <div className='mt-24 flex grow flex-col gap-24'>
-          {DATA_LIST.length > 0 ? (
-            DATA_LIST.map((item) => <CardList key={item.id} data={item} />)
+          {filteredData.length > 0 ? (
+            filteredData.map((item) => <CardList key={item.id} data={item} />)
           ) : (
             <div className='flex size-full grow items-center justify-center text-14 font-medium text-var-gray-500'>
               아직 아직 찜한 모임이 없어요.

--- a/src/app/api/actions/gatherings/getGatherings.ts
+++ b/src/app/api/actions/gatherings/getGatherings.ts
@@ -3,6 +3,7 @@
 import { GatheringsListData } from '@/types/data.type';
 
 interface GetGatheringsParams {
+  id?: string;
   limit?: number;
   offset?: number;
   type?: 'DALLAEMFIT' | 'OFFICE_STRETCHING' | 'MINDFULNESS' | 'WORKATION';

--- a/src/app/components/Badge/Badge.tsx
+++ b/src/app/components/Badge/Badge.tsx
@@ -1,5 +1,7 @@
+import { ReactNode } from 'react';
+
 interface BadgeProps {
-  children: string;
+  children: ReactNode;
 }
 
 const Badge = ({ children }: BadgeProps) => {

--- a/src/app/components/CardList/CardList.test.tsx
+++ b/src/app/components/CardList/CardList.test.tsx
@@ -97,26 +97,6 @@ describe('Tag Component Render', () => {
   });
 });
 
-// 마감된 챌린지일 경우 (isChallengeEnded)
-describe('isChallengeEnded Layer Render', () => {
-  beforeEach(() => {
-    const date = new Date();
-    date.setDate(date.getDate() - 1); // 하루 전 날짜로 설정
-
-    const MOCK_DATA = {
-      ...MOCK_DATA_BASE,
-      dateTime: date.toISOString(),
-    };
-
-    render(<CardList data={MOCK_DATA} />);
-  });
-
-  it('should render isChallengeEnded layer when isChallengeEnded is true', () => {
-    const challengeEndedElement = screen.getByText(/마감된 챌린지예요/);
-    expect(challengeEndedElement).toBeInTheDocument();
-  });
-});
-
 // SAVED 아이콘 클릭으로 토글 테스트
 describe('Saved button Test', () => {
   it('should toggle isSaved state when handleToggleSave is called', () => {
@@ -128,28 +108,68 @@ describe('Saved button Test', () => {
     inactiveButton = screen.getByTestId('IconSaveInactive');
     activeButton = screen.queryByTestId('IconSaveActive');
 
-    // 초기 상태 - (inactive 아이콘 확인)
     expect(inactiveButton).toBeInTheDocument();
     expect(activeButton).not.toBeInTheDocument();
 
-    // 버튼 클릭하여 상태 변경
     fireEvent.click(inactiveButton);
 
-    // 아이콘이 변경되었는지 확인 (actove 아이콘 확인)
     inactiveButton = screen.queryByTestId('IconSaveInactive');
     activeButton = screen.getByTestId('IconSaveActive');
 
     expect(activeButton).toBeInTheDocument();
     expect(inactiveButton).not.toBeInTheDocument();
 
-    // 버튼 클릭하여 상태 변경
     fireEvent.click(activeButton);
 
     inactiveButton = screen.getByTestId('IconSaveInactive');
     activeButton = screen.queryByTestId('IconSaveActive');
 
-    // 초기와 같은 상태 (inactive 아이콘 확인)
     expect(inactiveButton).toBeInTheDocument();
     expect(activeButton).not.toBeInTheDocument();
+  });
+
+  // 아이콘 클릭 시 이벤트 핸들러 작동 여부 테스트
+  it('should call handleToggleSave when IconSaveInactive is clicked', () => {
+    const handleToggleSave = jest.fn();
+    render(
+      <CardList data={MOCK_DATA_BASE} handleButtonClick={handleToggleSave} />,
+    );
+
+    const inactiveButton = screen.getByTestId('IconSaveInactive');
+    fireEvent.click(inactiveButton);
+
+    expect(handleToggleSave).toHaveBeenCalled();
+
+    const activeButton = screen.getByTestId('IconSaveActive');
+    expect(activeButton).toBeInTheDocument();
+  });
+});
+
+// 마감된 챌린지일 경우 (isChallengeEnded)
+describe('isChallengeEnded Layer Render', () => {
+  const handleToggleSave = jest.fn();
+
+  beforeEach(() => {
+    const date = new Date();
+    date.setDate(date.getDate() - 1); // 하루 전 날짜로 설정
+
+    const MOCK_DATA = {
+      ...MOCK_DATA_BASE,
+      dateTime: date.toISOString(),
+    };
+
+    render(<CardList data={MOCK_DATA} handleButtonClick={handleToggleSave} />);
+  });
+
+  it('should render isChallengeEnded layer when isChallengeEnded is true', () => {
+    const challengeEndedElement = screen.getByText(/마감된 챌린지예요/);
+    expect(challengeEndedElement).toBeInTheDocument();
+  });
+
+  it('should call handleButtonClick when IconSaveDiscardBtn is clicked', () => {
+    const discardButton = screen.getByTestId('IconSaveDiscard');
+    fireEvent.click(discardButton);
+
+    expect(handleToggleSave).toHaveBeenCalled();
   });
 });

--- a/src/app/components/CardList/CardList.tsx
+++ b/src/app/components/CardList/CardList.tsx
@@ -17,13 +17,16 @@ import { GatheringsListData } from '@/types/data.type';
 import Tag from '@/app/components/Tag/Tag';
 import InfoChip from '@/app/components/Chip/InfoChip';
 import ProgressBar from '@/app/components/ProgressBar/ProgressBar';
-import { useState } from 'react';
+import { MouseEvent, useEffect, useState } from 'react';
+import { useSavedGatheringList } from '@/context/SavedGatheringContext';
 
 interface CardProps {
   data: GatheringsListData;
 }
 
 const CardList = ({ data }: CardProps) => {
+  const { savedGatherings, updateGathering } = useSavedGatheringList();
+
   // 모임의 날짜와 현재 날짜를 비교하여 태그 렌더링
   const isRenderTag = isSameDate(data.registrationEnd);
 
@@ -32,10 +35,16 @@ const CardList = ({ data }: CardProps) => {
 
   const [isSaved, setIsSaved] = useState<boolean>(false);
 
-  const handleToggleSave = () => {
-    setIsSaved((prev) => !prev);
-    // TODO : storage 변경 코드
+  const handleToggleSave = (e: MouseEvent) => {
+    e.preventDefault();
+    updateGathering(data.id);
   };
+
+  useEffect(() => {
+    if (savedGatherings.length > 0) {
+      setIsSaved(savedGatherings.includes(data.id));
+    }
+  }, [savedGatherings]);
 
   return (
     <div className='relative flex w-full flex-col overflow-hidden rounded-[24px] border-2 border-var-gray-100 bg-white transition-all duration-300 hover:drop-shadow-[0_10px_10px_rgba(0,0,0,0.04)] md:flex-row'>
@@ -94,7 +103,7 @@ const CardList = ({ data }: CardProps) => {
 
       {/* 종료된 챌린지의 경우 */}
       {isChallengeEnded && (
-        <div className='absolute left-0 top-0 z-base flex h-full w-full flex-col items-center justify-center bg-var-black bg-opacity-80'>
+        <div className='z-base absolute left-0 top-0 flex h-full w-full flex-col items-center justify-center bg-var-black bg-opacity-80'>
           <p className='text-14 font-medium text-white'>
             마감된 챌린지예요.
             <br />

--- a/src/app/components/CardList/CardList.tsx
+++ b/src/app/components/CardList/CardList.tsx
@@ -19,6 +19,7 @@ import InfoChip from '@/app/components/Chip/InfoChip';
 import ProgressBar from '@/app/components/ProgressBar/ProgressBar';
 import { MouseEvent, useState } from 'react';
 
+// TODO : optional props를 필수로 변경
 interface CardProps {
   data: GatheringsListData;
   isSaved?: boolean;

--- a/src/app/components/CardList/CardList.tsx
+++ b/src/app/components/CardList/CardList.tsx
@@ -17,34 +17,30 @@ import { GatheringsListData } from '@/types/data.type';
 import Tag from '@/app/components/Tag/Tag';
 import InfoChip from '@/app/components/Chip/InfoChip';
 import ProgressBar from '@/app/components/ProgressBar/ProgressBar';
-import { MouseEvent, useEffect, useState } from 'react';
-import { useSavedGatheringList } from '@/context/SavedGatheringContext';
+import { MouseEvent, useState } from 'react';
 
 interface CardProps {
   data: GatheringsListData;
+  isSaved?: boolean;
+  handleButtonClick?: (id: number) => void;
 }
 
-const CardList = ({ data }: CardProps) => {
-  const { savedGatherings, updateGathering } = useSavedGatheringList();
-
+const CardList = ({ data, isSaved, handleButtonClick }: CardProps) => {
   // 모임의 날짜와 현재 날짜를 비교하여 태그 렌더링
   const isRenderTag = isSameDate(data.registrationEnd);
 
   // 모임의 날짜와 현재 날짜를 비교하여 마감 여부 표시
   const isChallengeEnded = new Date(data.dateTime) <= new Date();
 
-  const [isSaved, setIsSaved] = useState<boolean>(false);
+  const [isSavedActive, setSavedActive] = useState<boolean>(isSaved || false);
 
   const handleToggleSave = (e: MouseEvent) => {
     e.preventDefault();
-    updateGathering(data.id);
-  };
-
-  useEffect(() => {
-    if (savedGatherings.length > 0) {
-      setIsSaved(savedGatherings.includes(data.id));
+    setSavedActive(!isSavedActive);
+    if (handleButtonClick) {
+      handleButtonClick(data.id);
     }
-  }, [savedGatherings]);
+  };
 
   return (
     <div className='relative flex w-full flex-col overflow-hidden rounded-[24px] border-2 border-var-gray-100 bg-white transition-all duration-300 hover:drop-shadow-[0_10px_10px_rgba(0,0,0,0.04)] md:flex-row'>
@@ -79,7 +75,7 @@ const CardList = ({ data }: CardProps) => {
               <InfoChip type='time'>{formatTimeColon(data.dateTime)}</InfoChip>
             </div>
           </div>
-          {isSaved ? (
+          {isSavedActive ? (
             <IconSaveActive
               className='h-48 w-48 animate-heartPulse cursor-pointer'
               onClick={handleToggleSave}
@@ -112,7 +108,7 @@ const CardList = ({ data }: CardProps) => {
           <button
             type='button'
             className='right-24 mt-24 md:absolute md:top-24 md:mt-0'
-            // TODO : onClick={}
+            onClick={handleToggleSave}
           >
             <IconSaveDiscardBtn className='h-36 w-116 md:hidden' />
             <IconSaveDiscard className='hidden h-48 w-48 md:block' />

--- a/src/app/components/Filters/Filters.tsx
+++ b/src/app/components/Filters/Filters.tsx
@@ -1,0 +1,53 @@
+import Filter from '@/app/components/Filter/Filter';
+import FilterDate from '@/app/components/Filter/FilterDate';
+import { LOCATION_OPTIONS, SORT_OPTIONS } from '@/constants/common';
+
+interface FiltersProps {
+  onLocationChange: (location: string | undefined) => void;
+  onDateChange: (date: Date | null) => void;
+  onSortChange: (sortOption: string | undefined) => void;
+}
+
+const Filters = ({
+  onLocationChange,
+  onDateChange,
+  onSortChange,
+}: FiltersProps) => {
+  const handleLocationSelect = (selectedOption: string | undefined) => {
+    onLocationChange(selectedOption);
+  };
+
+  const handleSortSelect = (sortOption: string | undefined) => {
+    onSortChange(sortOption);
+  };
+
+  return (
+    <div className='flex justify-between pt-16'>
+      <div className='flex space-x-8'>
+        <Filter
+          type='list'
+          state='default'
+          options={LOCATION_OPTIONS}
+          onSelect={handleLocationSelect}
+        >
+          지역 전체
+        </Filter>
+        <FilterDate state='default' onSelectDate={onDateChange}>
+          날짜 전체
+        </FilterDate>
+      </div>
+      <div>
+        <Filter
+          type='sort'
+          state='default'
+          options={SORT_OPTIONS}
+          onSelect={handleSortSelect}
+        >
+          정렬
+        </Filter>
+      </div>
+    </div>
+  );
+};
+
+export default Filters;

--- a/src/app/components/Gnb/Gnb.tsx
+++ b/src/app/components/Gnb/Gnb.tsx
@@ -6,9 +6,8 @@ import { usePathname } from 'next/navigation';
 import UserStatus from './UserStatus';
 import TopTab from '../Tab/TopTab';
 import Badge from '../Badge/Badge';
-
-/* @todo 웹 스토리지에 저장된 찜한 모임의 length를 추출하는 방식으로 변경 예정 */
-const favoriteGroups = '12';
+import { useSavedGatheringList } from '@/context/SavedGatheringContext';
+import { useEffect, useState } from 'react';
 
 //@todo pathname 정해질 시 추가 예정
 const navList = [
@@ -29,18 +28,17 @@ const navList = [
 const Gnb = () => {
   const pathname = usePathname();
 
-  /* 찜한 모임 배지 렌더링 함수
-  nav.name이 '찜한 모임'이고 웹스토리지에 저장된 '찜한 모임'의 개수가 1개 이상일 시 Badge 렌더링 */
-  const renderBadge = (name: string) => {
-    return name === '찜한 모임' && Number(favoriteGroups) > 0 ? (
-      <div className='py-[18px]'>
-        <Badge>{favoriteGroups}</Badge>
-      </div>
-    ) : null;
-  };
+  const { savedGatherings } = useSavedGatheringList();
+  const [savedCount, setSavedCount] = useState<number>(0);
+
+  useEffect(() => {
+    if (savedGatherings.length > 0) {
+      setSavedCount(savedGatherings.length);
+    }
+  }, [savedGatherings]);
 
   return (
-    <header className='fixed left-0 top-0 z-nav w-full border-b-2 border-var-gray-900 bg-var-orange-600'>
+    <header className='z-nav fixed left-0 top-0 w-full border-b-2 border-var-gray-900 bg-var-orange-600'>
       <div className='mx-16 flex max-w-[1200px] items-center justify-between md:mx-24 lg:mx-auto'>
         <nav className='flex items-center'>
           <Link href='/'>
@@ -54,7 +52,12 @@ const Gnb = () => {
                     {nav.name}
                   </TopTab>
                 </Link>
-                {renderBadge(nav.name)}
+                {/* nav.name이 '찜한 모임'이고 웹스토리지에 저장된 '찜한 모임'의 개수가 1개 이상일 시 Badge 렌더링 */}
+                {nav.name === '찜한 모임' && savedCount > 0 && (
+                  <div className='py-[18px]'>
+                    <Badge>{savedCount}</Badge>
+                  </div>
+                )}
               </li>
             ))}
           </ul>

--- a/src/app/components/Tab/Tab.tsx
+++ b/src/app/components/Tab/Tab.tsx
@@ -13,7 +13,7 @@ const Tab = ({ type, isActive, onClick }: TabProps) => {
 
   return (
     <div
-      className={`relative flex cursor-pointer items-center gap-4 overflow-hidden px-4 pb-4 text-18 font-semibold transition ${styles} before:absolute before:bottom-0 before:w-full before:border-b-2 before:border-var-gray-900 before:transition-all before:duration-300`}
+      className={`relative flex cursor-pointer items-center gap-4 overflow-hidden px-8 pb-4 text-18 font-semibold transition ${styles} before:absolute before:bottom-0 before:w-full before:border-b-2 before:border-var-gray-900 before:transition-all before:duration-300`}
       onClick={onClick}
     >
       {type === 'workation' ? (

--- a/src/app/components/Tabs/Tabs.tsx
+++ b/src/app/components/Tabs/Tabs.tsx
@@ -7,7 +7,7 @@ interface TabsProps {
 
 const Tabs = ({ activeTab, onTabClick }: TabsProps) => {
   return (
-    <div className='flex space-x-12'>
+    <div className='flex items-center'>
       <Tab
         type='dalaemfit'
         isActive={activeTab === 'DALLAEMFIT'}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import '@/styles/reset.css';
 import '@/styles/style.css';
 import Gnb from './components/Gnb/Gnb';
 import Providers from './providers';
+import { SavedGatheringProvider } from '@/context/SavedGatheringContext';
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -18,11 +19,13 @@ export default function RootLayout({
   return (
     <html lang='ko'>
       <body className='flex min-h-dvh flex-col bg-var-gray-100 font-pretendard'>
-        <Gnb />
-        <Providers>
-          <div className='grow pt-60'>{children}</div>
-        </Providers>
-        <div id='modal-root'></div>
+        <SavedGatheringProvider>
+          <Gnb />
+          <Providers>
+            <div className='grow pt-60'>{children}</div>
+          </Providers>
+          <div id='modal-root'></div>
+        </SavedGatheringProvider>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,13 +19,11 @@ export default function RootLayout({
   return (
     <html lang='ko'>
       <body className='flex min-h-dvh flex-col bg-var-gray-100 font-pretendard'>
-        <SavedGatheringProvider>
+        <Providers>
           <Gnb />
-          <Providers>
-            <div className='grow pt-60'>{children}</div>
-          </Providers>
+          <div className='grow pt-60'>{children}</div>
           <div id='modal-root'></div>
-        </SavedGatheringProvider>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { UserProvider } from './(auth)/context/UserContext';
+import { SavedGatheringProvider } from '@/context/SavedGatheringContext';
 
 // QueryClient 인스턴스를 생성하는 함수
 function makeQueryClient() {
@@ -39,7 +40,11 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   // QueryClientProvider로 자식 컴포넌트들을 감싸서 QueryClient를 제공
   return (
     <UserProvider>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <SavedGatheringProvider>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </SavedGatheringProvider>
     </UserProvider>
   );
 }

--- a/src/context/SavedGatheringContext.tsx
+++ b/src/context/SavedGatheringContext.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from 'react';
+
+interface SavedGatheringContextProps {
+  savedGatherings: number[];
+  updateGathering: (item: number) => void;
+}
+
+const SavedGatheringContext = createContext<
+  SavedGatheringContextProps | undefined
+>(undefined);
+
+const SavedGatheringProvider = ({ children }: { children: ReactNode }) => {
+  // 찜한 모임의 Id 목록
+  const [savedGatherings, setSavedGatherings] = useState<number[]>([]);
+
+  // 최초 컴포넌트 렌더링 시 로컬 스토리지에서 데이터를 가져와서 상태에 저장한다.
+  useEffect(() => {
+    const savedIdList = localStorage.getItem('savedGathering');
+    if (savedIdList) {
+      setSavedGatherings(JSON.parse(savedIdList));
+    }
+  }, []);
+
+  // savedGatherings가 변경될 때마다 로컬 스토리지에 저장한다.
+  useEffect(() => {
+    if (savedGatherings.length > 0) {
+      localStorage.setItem('savedGathering', JSON.stringify(savedGatherings));
+    } else {
+      localStorage.removeItem('savedGathering');
+    }
+  }, [savedGatherings]);
+
+  // 찜한 모임 목록을 업데이트
+  const updateGathering = (id: number) => {
+    const existingItemIndex = savedGatherings.findIndex(
+      (gathering) => gathering === id,
+    );
+
+    if (existingItemIndex !== -1) {
+      setSavedGatherings((prev) =>
+        prev.filter((gathering) => gathering !== id),
+      );
+    } else {
+      setSavedGatherings((prev) => [...prev, id]);
+    }
+  };
+
+  return (
+    <SavedGatheringContext.Provider
+      value={{ savedGatherings, updateGathering }}
+    >
+      {children}
+    </SavedGatheringContext.Provider>
+  );
+};
+
+const useSavedGatheringList = (): SavedGatheringContextProps => {
+  const context = useContext(SavedGatheringContext);
+  if (!context) {
+    throw new Error(
+      'useSavedGathering must be used within a SavedGatheringProvider',
+    );
+  }
+  return context;
+};
+
+export { SavedGatheringProvider, useSavedGatheringList };

--- a/src/types/client.type.ts
+++ b/src/types/client.type.ts
@@ -17,3 +17,6 @@ export interface UserData {
   createdAt: string;
   updatedAt: string;
 }
+
+export type GatheringTabsType = 'WORKATION' | 'DALLAEMFIT';
+export type GatheringChipsType = 'ALL' | 'OFFICE_STRETCHING' | 'MINDFULNESS';


### PR DESCRIPTION
## ✏️ 작업 내용
- 찜한 모임 페이지 api 연동
- 로컬 스토리지 get, set 을 위한 context api 추가
- 기타 컴포넌트 수정

## 📷 스크린샷
- Gatherings 에서 찜하기 후, Saved 페이지로 넘어갑니다~

https://github.com/user-attachments/assets/8cffedf0-cf2c-4e00-919d-431e2fe9e121


## ✍️ 사용법
````jsx
interface SavedListProps {
  dataList: GatheringsListData[];
}

const SavedList = ({ dataList }: SavedListProps) => {
  // 로컬스토리지에 대한 Context
  const { savedGatherings, updateGathering } = useSavedGatheringList();

  // 모임 Id를 파라미터로 받아, 로컬스토리지에 저장되어 있는지 여부를 확인합니다.
  const isSaved = (id: number) => savedGatherings.includes(id);

  // CardList의 버튼 클릭 시 작동되는 함수입니다.
  // 모임 Id를 파라미터로 받아, 로컬스토리지를 업데이트 합니다. (추가 or 삭제)
  const handleButtonClick = (id: number) => {
    updateGathering(id);
  };

  return (
    <>
      {dataList.map((item) => (
        <CardList
          key={item.id}
          data={item}
          isSaved={isSaved(item.id)}
          handleButtonClick={handleButtonClick}
        />
      ))}
    </>
  );
};
````


## 🎸 기타
#### Check point
- CardList 컴포넌트에서 HeartIcon 버튼 클릭 시 로컬스토리지에 저장 / 삭제 토글
- 로컬 스토리지 저장 및 삭제 시 GNB의 badge 숫자 반영
- /saved 페이지에서 달램핏/워케이션 타입에 따라 data fetch
- 오피스 스트레칭/마인드풀니스 칩에 따라 필터링
- 지역에 따른 필터링
- 최신순, 마감임박순 등 정렬

#### Issue
- 필터링 된 상태에서 찜한 모임 삭제 시 필터 상태가 초기화
- 날짜 filter 안 됨

#### ToDo
- Issue 해결
- 컴포넌트 분리 (상태관리, 비즈니스 로직 분리 등....)


아주 기본적인 기능만 완성한 상태로, 코드 수정 양이 많을 것 같아 중간동기화 겸 PR 올립니다!
현재 Page 컴포넌트 하나에 너무 많은 책임이 있어 분리할 예정인데, 아이디어 주시면 감사하겠습니다
로컬 스토리지 get, set 상태에서 자잘한 이슈가 많이 있을 것으로 예상됩니다. 피드백 주시면 반영하겠습니다!

close #84 