### PR TITLE
refactor : 마이페이지/내가 만든 모임 페이지 리팩토링

### DIFF
--- a/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
+++ b/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
@@ -32,6 +32,7 @@ const ClientSideGatherings = ({
   return (
     <>
       <GatheringList dataList={gatheringsList} />
+      {/* TODO : 로딩 상태에 대해 논의 후 디자인 통일 */}
       {isLoading && <p>로딩 스피너</p>}
 
       {hasMore && <div ref={ref} className='h-20' />}

--- a/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
+++ b/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useUserCreated } from '@/hooks/useUserCreated';
+import GatheringList from './GatheringList';
+import { useInView } from 'react-intersection-observer';
+import { useEffect } from 'react';
+import { GatheringsListData } from '@/types/data.type';
+
+interface ClientSideGatheringsProps {
+  gatherings: GatheringsListData[];
+  createdBy: string;
+}
+
+const ClientSideGatherings = ({
+  gatherings,
+  createdBy,
+}: ClientSideGatheringsProps) => {
+  const { gatheringsList, isLoading, hasMore, loadMore } = useUserCreated(
+    gatherings,
+    createdBy,
+  );
+
+  const { ref, inView } = useInView({ threshold: 1.0 });
+
+  useEffect(() => {
+    if (inView && hasMore) {
+      loadMore();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inView, hasMore]);
+
+  return (
+    <>
+      <GatheringList dataList={gatheringsList} />
+      {isLoading && <p>로딩 스피너</p>}
+
+      {hasMore && <div ref={ref} className='h-20' />}
+    </>
+  );
+};
+
+export default ClientSideGatherings;

--- a/src/app/(main)/mypage/created/_component/GatheringList.tsx
+++ b/src/app/(main)/mypage/created/_component/GatheringList.tsx
@@ -2,6 +2,7 @@
 
 import Card from '@/app/components/Card/Card';
 import { GatheringsListData } from '@/types/data.type';
+import Link from 'next/link';
 
 interface GatheringListProps {
   dataList: GatheringsListData[];
@@ -22,9 +23,11 @@ const GatheringList = ({ dataList }: GatheringListProps) => {
   return (
     <div className='grow'>
       {updateDataList().map((data) => (
-        <Card key={data.id} handleSaveDiscard={handleSaveDiscard} data={data}>
-          <Card.Info />
-        </Card>
+        <Link key={data.id} href={`/gatherings/${data.id}`}>
+          <Card handleSaveDiscard={handleSaveDiscard} data={data}>
+            <Card.Info />
+          </Card>
+        </Link>
       ))}
     </div>
   );

--- a/src/app/(main)/mypage/created/page.tsx
+++ b/src/app/(main)/mypage/created/page.tsx
@@ -16,12 +16,10 @@ const CreatedPage = async () => {
   return (
     <>
       {gatherings.length > 0 ? (
-        <>
-          <ClientSideGatherings
-            createdBy={String(userData.id)}
-            gatherings={gatherings}
-          />
-        </>
+        <ClientSideGatherings
+          createdBy={String(userData.id)}
+          gatherings={gatherings}
+        />
       ) : (
         <div className='flex grow items-center justify-center text-14 font-medium text-var-gray-500'>
           아직 만든 모임이 없어요

--- a/src/app/(main)/mypage/created/page.tsx
+++ b/src/app/(main)/mypage/created/page.tsx
@@ -1,14 +1,15 @@
 import { getUserData } from '@/app/api/actions/mypage/getUserData';
 import ClientSideGatherings from './_component/ClientSideGatherings';
 import getGatherings from '@/app/api/actions/gatherings/getGatherings';
+import { redirect } from 'next/navigation';
 
 const CreatedPage = async () => {
   const userData = await getUserData();
 
   if (!userData) {
-    // TODO : userData가 없을 때 에러 처리 혹은 로그인 페이지로 이동
-    return null;
+    redirect('/signin');
   }
+
   const gatherings = await getGatherings({
     createdBy: String(userData.id),
   });

--- a/src/app/(main)/mypage/created/page.tsx
+++ b/src/app/(main)/mypage/created/page.tsx
@@ -1,40 +1,10 @@
 'use client';
 
-import getGatherings from '@/app/api/actions/gatherings/getGatherings';
+import { useUserCreated } from '@/hooks/useUserCreated';
 import GatheringList from './_component/GatheringList';
-import { GatheringsListData } from '@/types/data.type';
-import { useUser } from '@/app/(auth)/context/UserContext';
-import { useEffect, useState } from 'react';
-import { set } from 'zod';
-import { DATA_LIST } from './mockData';
 
 const CreatedPage = () => {
-  const { user } = useUser();
-  const [gatheringsList, setGatheringsList] = useState<GatheringsListData[]>(
-    [],
-  );
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchGatheringsData = async () => {
-      if (user) {
-        setIsLoading(true);
-
-        try {
-          const gatherings = await getGatherings({
-            createdBy: String(user.id),
-          });
-          setGatheringsList(gatherings);
-        } catch (error) {
-          console.error('Error fetching data:', error);
-        } finally {
-          setIsLoading(false); // 요청이 끝나면 로딩 상태 해제
-        }
-      }
-    };
-
-    fetchGatheringsData();
-  }, [user]);
+  const { gatheringsList, isLoading } = useUserCreated();
 
   return (
     <>

--- a/src/app/(main)/mypage/created/page.tsx
+++ b/src/app/(main)/mypage/created/page.tsx
@@ -1,19 +1,27 @@
-'use client';
+import { getUserData } from '@/app/api/actions/mypage/getUserData';
+import ClientSideGatherings from './_component/ClientSideGatherings';
+import getGatherings from '@/app/api/actions/gatherings/getGatherings';
 
-import { useUserCreated } from '@/hooks/useUserCreated';
-import GatheringList from './_component/GatheringList';
+const CreatedPage = async () => {
+  const userData = await getUserData();
 
-const CreatedPage = () => {
-  const { gatheringsList, isLoading } = useUserCreated();
+  if (!userData) {
+    // TODO : userData가 없을 때 에러 처리 혹은 로그인 페이지로 이동
+    return null;
+  }
+  const gatherings = await getGatherings({
+    createdBy: String(userData.id),
+  });
 
   return (
     <>
-      {isLoading ? (
-        <div className='flex grow items-center justify-center text-14 font-medium text-var-gray-500'>
-          모임 정보를 불러오고 있어요...
-        </div>
-      ) : gatheringsList.length > 0 ? (
-        <GatheringList dataList={gatheringsList} />
+      {gatherings.length > 0 ? (
+        <>
+          <ClientSideGatherings
+            createdBy={String(userData.id)}
+            gatherings={gatherings}
+          />
+        </>
       ) : (
         <div className='flex grow items-center justify-center text-14 font-medium text-var-gray-500'>
           아직 만든 모임이 없어요

--- a/src/app/components/Card/Card.tsx
+++ b/src/app/components/Card/Card.tsx
@@ -11,6 +11,7 @@ import StateChip from '@/app/components/Chip/StateChip';
 import { formatDate, formatTime } from '@/utils/formatDate';
 import { UserJoinedGatheringsData } from '@/types/data.type';
 import { createContext, PropsWithChildren, useContext } from 'react';
+import { MIN_PARTICIPANTS } from '@/constants/common';
 
 interface CardProps {
   data: UserJoinedGatheringsData;
@@ -71,7 +72,6 @@ const CardChips = (): JSX.Element => {
     );
   }
 
-  const MIN_PARTICIPANTS = 5;
   const isConfirmed = participantCount >= MIN_PARTICIPANTS;
   return (
     <div className='mb-[6px] flex gap-8'>

--- a/src/hooks/useUserCreated.ts
+++ b/src/hooks/useUserCreated.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+import getGatherings from '@/app/api/actions/gatherings/getGatherings';
+import { useUser } from '@/app/(auth)/context/UserContext';
+import { GatheringsListData } from '@/types/data.type';
+
+export const useUserCreated = () => {
+  const { user } = useUser();
+  const [gatheringsList, setGatheringsList] = useState<GatheringsListData[]>(
+    [],
+  );
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchGatheringsData = async () => {
+      if (user) {
+        setIsLoading(true);
+
+        try {
+          const gatherings = await getGatherings({
+            createdBy: String(user.id),
+          });
+          setGatheringsList(gatherings);
+        } catch (error) {
+          console.error('Error fetching data:', error);
+        } finally {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchGatheringsData();
+  }, [user]);
+
+  return { gatheringsList, isLoading };
+};


### PR DESCRIPTION
## ✏️ 작업 내용
- 모임 클릭 시 모임 상세 페이지 (gatherings/[id]) 로 이동 : 해당 모임에 대한 개별 리뷰를 확인하기 위함
- Page 컴포넌트의 코드를 뷰 레이어와 비즈니스 로직 레이어로 계층화하여 분리

#### User Data를 Context API가 아닌 Server Side에서 `getUserData()` 를 사용하여 조회
이에 요구사항에는 없지만, Client Side가 아닌 Server Side에서 데이터를 조회하게 하였습니다.
API의 기본적인 offset이 10 으로 처리되어 있기 때문에, 그 이상의 데이터는 무한스크롤을 통해 추가로 확보합니다. 

## 📷 스크린샷
**무한스크롤을 보여드리기 위해, 최초 1개의 데이터, 이후 1개씩 데이터 받아오도록 설정하여 녹화한 상태입니다.**

![Screenshot 2024-10-01 at 15 15 24](https://github.com/user-attachments/assets/e6d58b54-73b1-4c69-b5b6-bc15b46fafed)
## ✍️ 사용법

## 🎸 기타

close #114 