### PR TITLE
[KAN-96] fix: getGathering api 요청 시 버그 수정

### DIFF
--- a/src/app/(main)/mypage/created/page.tsx
+++ b/src/app/(main)/mypage/created/page.tsx
@@ -2,6 +2,7 @@ import { getUserData } from '@/app/api/actions/mypage/getUserData';
 import ClientSideGatherings from './_component/ClientSideGatherings';
 import getGatherings from '@/app/api/actions/gatherings/getGatherings';
 import { redirect } from 'next/navigation';
+import { SORT_OPTIONS_MAP } from '@/constants/common';
 
 const CreatedPage = async () => {
   const userData = await getUserData();
@@ -12,6 +13,8 @@ const CreatedPage = async () => {
 
   const gatherings = await getGatherings({
     createdBy: String(userData.id),
+    sortBy: SORT_OPTIONS_MAP['최신순'],
+    sortOrder: 'desc',
   });
 
   return (

--- a/src/hooks/useSavedGatherings.ts
+++ b/src/hooks/useSavedGatherings.ts
@@ -56,6 +56,9 @@ const useSavedGatherings = (savedGatherings: number[]) => {
       if (sortOption) {
         params.sortBy = SORT_OPTIONS_MAP[sortOption];
         params.sortOrder = 'desc';
+      } else {
+        params.sortBy = SORT_OPTIONS_MAP['최신순'];
+        params.sortOrder = 'desc';
       }
 
       getSavedGatherings(params);

--- a/src/hooks/useUserCreated.ts
+++ b/src/hooks/useUserCreated.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import getGatherings from '@/app/api/actions/gatherings/getGatherings';
 import { GatheringsListData } from '@/types/data.type';
-import { LIMIT_PER_REQUEST } from '@/constants/common';
+import { LIMIT_PER_REQUEST, SORT_OPTIONS_MAP } from '@/constants/common';
 
 export const useUserCreated = (
   initialGatheringList: GatheringsListData[],
@@ -27,6 +27,8 @@ export const useUserCreated = (
         createdBy: createdBy,
         offset: newOffset,
         limit: LIMIT_PER_REQUEST,
+        sortBy: SORT_OPTIONS_MAP['최신순'],
+        sortOrder: 'desc',
       });
 
       if (gatherings.length < LIMIT_PER_REQUEST) {


### PR DESCRIPTION
## ✏️ 작업 내용
- getGathering API 의 파라미터에서 `sortBy, sortOrder` 의 기본값이 사라지면서, 
찜한 모임 / 내가 만든 모임에서 API 요청 시  `sortBy, sortOrder`  파라미터를 추가하도록 했습니다.

## 📷 스크린샷

## ✍️ 사용법

## 🎸 기타
