### PR TITLE
refactor: Loader 컴포넌트 수정 및 적용

### DIFF
--- a/src/app/(auth)/loading.tsx
+++ b/src/app/(auth)/loading.tsx
@@ -1,7 +1,13 @@
-import Loader from '../components/Loader/Loader';
+'use client';
+
+import Loader from '@/app/components/Loader/Loader';
 
 const Loading = () => {
-  return <Loader />;
+  return (
+    <div className='flex min-h-screen items-center justify-center'>
+      <Loader />;
+    </div>
+  );
 };
 
 export default Loading;

--- a/src/app/(main)/gatherings/_component/ClientSideGatherings.tsx
+++ b/src/app/(main)/gatherings/_component/ClientSideGatherings.tsx
@@ -83,9 +83,13 @@ const ClientSideGatherings = ({
       </div>
       <GatheringCardList gatherings={filteredData} />
 
-      {isLoading && <Loader />}
+      {isLoading && (
+        <div className='flex items-center justify-center pt-24'>
+          <Loader />
+        </div>
+      )}
 
-      {hasMore && <div ref={ref} className='h-20' />}
+      {hasMore && <div ref={ref} className='h-24' />}
 
       {isModalOpen && (
         <MakeGatheringModal onClose={() => setIsModalOpen(false)} />

--- a/src/app/(main)/gatherings/loading.tsx
+++ b/src/app/(main)/gatherings/loading.tsx
@@ -1,7 +1,13 @@
+'use client';
+
 import Loader from '@/app/components/Loader/Loader';
 
 const Loading = () => {
-  return <Loader />;
+  return (
+    <div className='flex min-h-screen items-center justify-center'>
+      <Loader />;
+    </div>
+  );
 };
 
 export default Loading;

--- a/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
+++ b/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
@@ -5,6 +5,7 @@ import GatheringList from './GatheringList';
 import { useInView } from 'react-intersection-observer';
 import { useEffect } from 'react';
 import { GatheringsListData } from '@/types/data.type';
+import Loader from '@/app/components/Loader/Loader';
 
 interface ClientSideGatheringsProps {
   gatherings: GatheringsListData[];
@@ -32,8 +33,11 @@ const ClientSideGatherings = ({
   return (
     <>
       <GatheringList dataList={gatheringsList} />
-      {/* TODO : 로딩 상태에 대해 논의 후 디자인 통일 */}
-      {isLoading && <p>로딩 스피너</p>}
+      {isLoading && (
+        <div className='flex items-center justify-center pt-24'>
+          <Loader />
+        </div>
+      )}
 
       {hasMore && <div ref={ref} className='h-20' />}
     </>

--- a/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
+++ b/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
@@ -39,7 +39,7 @@ const ClientSideGatherings = ({
         </div>
       )}
 
-      {hasMore && <div ref={ref} className='h-20' />}
+      {hasMore && <div ref={ref} className='h-24' />}
     </>
   );
 };

--- a/src/app/(main)/reviews/_components/ClientSideReviews.tsx
+++ b/src/app/(main)/reviews/_components/ClientSideReviews.tsx
@@ -59,7 +59,9 @@ const ClientSideReviews = ({
       {/* 별점칸 */}
       <ReviewScore initialScore={filteredSortData} />
 
-      <div className='mt-24 flex grow flex-col border-t-2 border-t-var-gray-900 bg-white p-24 pt-8'>
+      <div
+        className={`mt-24 flex grow flex-col border-t-2 border-t-var-gray-900 bg-white px-24 pt-8 ${!hasMore && 'pb-24'}`}
+      >
         <Filters
           onLocationChange={handleLocationChange}
           onDateChange={handleDateChange}
@@ -76,7 +78,7 @@ const ClientSideReviews = ({
               </div>
             )}
 
-            {hasMore && <div ref={ref} className='h-20' />}
+            {hasMore && <div ref={ref} className='h-24' />}
           </>
         ) : (
           <div className='flex grow items-center justify-center text-14 font-medium text-var-gray-500'>

--- a/src/app/(main)/reviews/_components/ClientSideReviews.tsx
+++ b/src/app/(main)/reviews/_components/ClientSideReviews.tsx
@@ -9,6 +9,7 @@ import Chips from './Chips';
 import Filters from './Filters';
 import { useInView } from 'react-intersection-observer';
 import { useEffect } from 'react';
+import Loader from '@/app/components/Loader/Loader';
 
 interface ClientSideReviewsProps {
   reviewListData: ReviewsType[];
@@ -69,8 +70,11 @@ const ClientSideReviews = ({
           <>
             <ReviewList reviewList={filteredData} />
 
-            {/* TODO : 로딩 컴포넌트 */}
-            {isLoading && <p>로딩...</p>}
+            {isLoading && (
+              <div className='flex items-center justify-center pt-24'>
+                <Loader />
+              </div>
+            )}
 
             {hasMore && <div ref={ref} className='h-20' />}
           </>

--- a/src/app/components/Loader/Loader.tsx
+++ b/src/app/components/Loader/Loader.tsx
@@ -1,10 +1,32 @@
+import { CSSProperties } from 'react';
 import { PulseLoader } from 'react-spinners';
 
-const Loader = () => {
+interface LoaderProps {
+  size?: number | string;
+  margin?: number | string;
+  color?: string;
+  loading?: boolean;
+  cssOverride?: CSSProperties;
+  speedMultiplier?: number;
+}
+
+const Loader = (props: LoaderProps) => {
+  const {
+    size = 12,
+    margin = 6,
+    color = '#EA580C',
+    speedMultiplier = 0.7,
+    ...rest
+  } = props;
+
   return (
-    <div className='flex min-h-screen items-center justify-center'>
-      <PulseLoader color='#EA580C' />
-    </div>
+    <PulseLoader
+      size={size}
+      margin={margin}
+      color={color}
+      speedMultiplier={speedMultiplier}
+      {...rest}
+    />
   );
 };
 

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,7 +1,13 @@
-import Loader from './components/Loader/Loader';
+'use client';
+
+import Loader from '@/app/components/Loader/Loader';
 
 const Loading = () => {
-  return <Loader />;
+  return (
+    <div className='flex min-h-screen items-center justify-center'>
+      <Loader />;
+    </div>
+  );
 };
 
 export default Loading;


### PR DESCRIPTION
## ✏️ 작업 내용
- Loader 컴포넌트에 기본으로 추가된 wrapper를 삭제하였습니다.
- Loader 컴포넌트의 props를 추가하여 스타일 변경이 가능하게 하였습니다.
- loading.tsx 파일에 wrapper 추가 및 'use client' 를 선언하였습니다.
- 기타 페이지에 loader 컴포넌트를 적용하였습니다.

## 📷 스크린샷
**기존 스타일** 
![loader-before](https://github.com/user-attachments/assets/fc1e0592-4f0e-488b-a96e-26239603c608)

**변경 스타일 : size, margin, 애니메이션 속도 조정**
![loader-after](https://github.com/user-attachments/assets/a276555f-ddd2-4917-9f3a-a3fc60921891)

**무한스크롤 내 기존 : loader 컴포넌트 자체에 적용된 wrapper 스타일 때문에, loading 영역이 큼**
![loading-before](https://github.com/user-attachments/assets/e9f41989-7758-4aa8-a424-6474ed79be86)

**무한스크롤 변경 적용**
![loading-after](https://github.com/user-attachments/assets/994bcb7c-5dc2-4bb9-a65d-59eaaf057b0e)

## ✍️ 사용법
```
<div className='flex items-center justify-center ..... 그 외 wrapper에 적용할 classname'>
      <Loader />
</div>
```

## 🎸 기타
호민님이 만들어주신 loader 컴포넌트의 약간의 수정을 더했습니다.