### PR TITLE
fix: 모임 생성 후 모임 상세페이지로 이동하는 기능 구현

### DIFF
--- a/src/app/api/actions/gatherings/postGatherings.ts
+++ b/src/app/api/actions/gatherings/postGatherings.ts
@@ -1,29 +1,14 @@
+'use server';
+
 import { getCookie } from '@/actions/auth/cookie/cookie';
 
-interface PostGatheringsParams {
-  location: string;
-  type: string;
-  dateTime: string;
-  capacity: number;
-  image: File;
-  registrationEnd?: string;
-}
-
-const postGatherings = async (params: PostGatheringsParams) => {
-  const { location, type, dateTime, capacity, image } = params;
+const postGatherings = async (formData: FormData) => {
   try {
     const token = await getCookie('token');
 
     if (!token) {
       return { success: false, message: '로그인이 필요합니다.' };
     }
-
-    const formData = new FormData();
-    formData.append('location', location);
-    formData.append('type', type);
-    formData.append('dateTime', dateTime);
-    formData.append('capacity', capacity.toString());
-    formData.append('image', image);
 
     const res = await fetch(
       `${process.env.NEXT_PUBLIC_API_BASE_URL}/gatherings`,
@@ -36,7 +21,8 @@ const postGatherings = async (params: PostGatheringsParams) => {
       },
     );
 
-    const { data } = await res.json();
+    const data = await res.json();
+
     return { success: true, data, message: '모임이 생성되었습니다.' };
   } catch (error) {
     return {

--- a/src/app/components/Modal/MakeGatheringModal.tsx
+++ b/src/app/components/Modal/MakeGatheringModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import postGatherings from '@/app/api/actions/gatherings/postGatherings';
 import { LOCATION_OPTIONS, MIN_PARTICIPANTS } from '@/constants/common';
 import { FormEvent, useState } from 'react';
@@ -19,6 +20,8 @@ interface MakeGatheringModalProps {
 }
 
 const MakeGatheringModal = ({ onClose }: MakeGatheringModalProps) => {
+  const router = useRouter();
+
   const [location, setLocation] = useState<string | null>(null);
   const [image, setImage] = useState<File | null>(null);
   const [gatheringType, setGatheringType] = useState<Record<string, boolean>>({
@@ -67,13 +70,14 @@ const MakeGatheringModal = ({ onClose }: MakeGatheringModalProps) => {
       return;
     }
 
-    const { success, message } = await postGatherings({
-      location: location as string,
-      type: getSelectedGatheringType(),
-      dateTime: (combinedDateTime as Date).toISOString(),
-      capacity,
-      image: image as File,
-    });
+    const formData = new FormData();
+    formData.append('location', location!);
+    formData.append('type', getSelectedGatheringType());
+    formData.append('dateTime', (combinedDateTime as Date).toISOString());
+    formData.append('capacity', capacity.toString());
+    formData.append('image', image as File);
+
+    const { success, message, data } = await postGatherings(formData);
 
     if (!success) {
       toast.error(message);
@@ -83,6 +87,8 @@ const MakeGatheringModal = ({ onClose }: MakeGatheringModalProps) => {
 
     onClose();
     toast.success(message);
+
+    router.push(`/gatherings/${data.id}`);
   };
 
   return (

--- a/src/app/components/Modal/MakeGatheringModal.tsx
+++ b/src/app/components/Modal/MakeGatheringModal.tsx
@@ -86,9 +86,10 @@ const MakeGatheringModal = ({ onClose }: MakeGatheringModalProps) => {
     }
 
     onClose();
-    toast.success(message);
 
     router.push(`/gatherings/${data.id}`);
+
+    toast.success(message);
   };
 
   return (


### PR DESCRIPTION
## ✏️ 작업 내용

- `postGatherings` 함수를 server actions 로 구현
- 모임 생성 후 모임 상세페이지로 이동하는 기능 구현

## 📷 스크린샷

https://github.com/user-attachments/assets/907b9ab6-e45d-46ae-877d-9d8e8bb42060

## ✍️ 사용법

## 🎸 기타

### postGatherings 

`formData` 를 client 에서 append 하는 로직으로 수정하였습니다!
왜 그런진 모르겠지만, 서버에서 append 를 하면 잘 동작하지 않더라구요..!
그 부분은 찾아볼 예정입니다.