### PR TITLE
refactor: 내가 만든 모임 페이지 react-query 무한 스크롤 적용

### DIFF
--- a/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
+++ b/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import toast from 'react-hot-toast';
 import { useUserCreated } from '@/hooks/useUserCreated';
 import GatheringList from './GatheringList';
 import { useInView } from 'react-intersection-observer';
@@ -16,10 +17,14 @@ const ClientSideGatherings = ({
   initialGatheringList,
   createdBy,
 }: ClientSideGatheringsProps) => {
-  const { gatheringsList, isLoading, hasMore, loadMore } = useUserCreated(
-    initialGatheringList,
-    createdBy,
-  );
+  const { gatheringsList, isLoading, hasMore, loadMore, isError, error } =
+    useUserCreated(initialGatheringList, createdBy);
+
+  useEffect(() => {
+    if (isError) {
+      toast.error(error?.message || '오류가 발생했습니다.');
+    }
+  }, [isError, error]);
 
   const { ref, inView } = useInView({ threshold: 1.0 });
 

--- a/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
+++ b/src/app/(main)/mypage/created/_component/ClientSideGatherings.tsx
@@ -8,16 +8,16 @@ import { GatheringsListData } from '@/types/data.type';
 import Loader from '@/app/components/Loader/Loader';
 
 interface ClientSideGatheringsProps {
-  gatherings: GatheringsListData[];
+  initialGatheringList: GatheringsListData[];
   createdBy: string;
 }
 
 const ClientSideGatherings = ({
-  gatherings,
+  initialGatheringList,
   createdBy,
 }: ClientSideGatheringsProps) => {
   const { gatheringsList, isLoading, hasMore, loadMore } = useUserCreated(
-    gatherings,
+    initialGatheringList,
     createdBy,
   );
 
@@ -32,7 +32,7 @@ const ClientSideGatherings = ({
 
   return (
     <>
-      <GatheringList dataList={gatheringsList} />
+      <GatheringList dataList={gatheringsList.pages.flat()} />
       {isLoading && (
         <div className='flex items-center justify-center pt-24'>
           <Loader />

--- a/src/app/(main)/mypage/created/page.tsx
+++ b/src/app/(main)/mypage/created/page.tsx
@@ -22,7 +22,7 @@ const CreatedPage = async () => {
       {gatherings.length > 0 ? (
         <ClientSideGatherings
           createdBy={String(userData.id)}
-          gatherings={gatherings}
+          initialGatheringList={gatherings}
         />
       ) : (
         <div className='flex grow items-center justify-center text-14 font-medium text-var-gray-500'>

--- a/src/hooks/useUserCreated.ts
+++ b/src/hooks/useUserCreated.ts
@@ -1,50 +1,58 @@
-import { useState } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
 import getGatherings from '@/app/api/actions/gatherings/getGatherings';
 import { GatheringsListData } from '@/types/data.type';
-import { LIMIT_PER_REQUEST, SORT_OPTIONS_MAP } from '@/constants/common';
+import {
+  DEFAULT_OFFSET,
+  LIMIT_PER_REQUEST,
+  SORT_OPTIONS_MAP,
+} from '@/constants/common';
 
 export const useUserCreated = (
   initialGatheringList: GatheringsListData[],
   createdBy: string,
 ) => {
-  const [gatheringsList, setGatheringsList] =
-    useState<GatheringsListData[]>(initialGatheringList);
-  const [isLoading, setIsLoading] = useState(false);
-  const [hasMore, setHasMore] = useState<boolean>(
-    initialGatheringList.length >= LIMIT_PER_REQUEST,
-  );
-  const [offset, setOffset] = useState(0);
+  const {
+    data,
+    fetchNextPage, // loadMore
+    hasNextPage, // hasMore
+    isFetchingNextPage, // isLoading
+  } = useInfiniteQuery({
+    queryKey: ['created', createdBy],
+    queryFn: async ({ pageParam = DEFAULT_OFFSET }) => {
+      try {
+        const response = await getGatherings({
+          createdBy: createdBy,
+          limit: LIMIT_PER_REQUEST,
+          offset: pageParam,
+          sortBy: SORT_OPTIONS_MAP['최신순'],
+          sortOrder: 'desc',
+        });
 
-  const loadMore = async () => {
-    if (isLoading || !hasMore) return;
-
-    setIsLoading(true);
-
-    const newOffset = offset + LIMIT_PER_REQUEST;
-
-    try {
-      const gatherings = await getGatherings({
-        createdBy: createdBy,
-        offset: newOffset,
-        limit: LIMIT_PER_REQUEST,
-        sortBy: SORT_OPTIONS_MAP['최신순'],
-        sortOrder: 'desc',
-      });
-
-      if (gatherings.length < LIMIT_PER_REQUEST) {
-        setHasMore(false);
+        return response;
+      } catch (error) {
+        toast.error('모임 목록을 불러오는 중 오류가 발생했습니다');
+        throw error;
       }
+    },
+    getNextPageParam: (lastPage, allPages) => {
+      return lastPage && lastPage.length === LIMIT_PER_REQUEST
+        ? allPages.length * LIMIT_PER_REQUEST
+        : undefined;
+    },
+    initialPageParam: DEFAULT_OFFSET,
+    initialData: {
+      pages: [initialGatheringList],
+      pageParams: [DEFAULT_OFFSET],
+    },
+  });
 
-      setGatheringsList((prevData) => [...prevData, ...gatherings]);
-    } catch (error) {
-      console.error('Error fetching data:', error);
-    } finally {
-      setIsLoading(false);
-      setOffset(offset + LIMIT_PER_REQUEST);
-    }
+  return {
+    gatheringsList: data,
+    loadMore: fetchNextPage,
+    hasMore: hasNextPage,
+    isLoading: isFetchingNextPage,
   };
-
-  return { gatheringsList, isLoading, hasMore, loadMore };
 };
 
 export default useUserCreated;

--- a/src/hooks/useUserCreated.ts
+++ b/src/hooks/useUserCreated.ts
@@ -1,5 +1,4 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
 import getGatherings from '@/app/api/actions/gatherings/getGatherings';
 import { GatheringsListData } from '@/types/data.type';
 import {
@@ -17,6 +16,8 @@ export const useUserCreated = (
     fetchNextPage, // loadMore
     hasNextPage, // hasMore
     isFetchingNextPage, // isLoading
+    isError,
+    error,
   } = useInfiniteQuery({
     queryKey: ['created', createdBy],
     queryFn: async ({ pageParam = DEFAULT_OFFSET }) => {
@@ -31,8 +32,9 @@ export const useUserCreated = (
 
         return response;
       } catch (error) {
-        toast.error('모임 목록을 불러오는 중 오류가 발생했습니다');
-        throw error;
+        throw error instanceof Error
+          ? new Error(error.message)
+          : new Error('모임 목록을 불러오는 중 오류가 발생했습니다.');
       }
     },
     getNextPageParam: (lastPage, allPages) => {
@@ -52,6 +54,8 @@ export const useUserCreated = (
     loadMore: fetchNextPage,
     hasMore: hasNextPage,
     isLoading: isFetchingNextPage,
+    isError,
+    error,
   };
 };
 


### PR DESCRIPTION
## ✏️ 작업 내용
- 마이페이지 / 내가 만든 모임 페이지의 무한스크롤로 추가 data fetch를 react-query의 useInfiniteQuery 를 적용하였습니다.
-

## 📷 스크린샷

## ✍️ 사용법

## 🎸 기타
