### PR TITLE
fix : 로그인 페이지 layoutshift 현상 해결

### DIFF
--- a/src/app/(auth)/loading.tsx
+++ b/src/app/(auth)/loading.tsx
@@ -4,7 +4,7 @@ import Loader from '@/app/components/Loader/Loader';
 
 const Loading = () => {
   return (
-    <div className='flex min-h-screen items-center justify-center'>
+    <div className='flex min-h-360 items-center justify-center'>
       <Loader />;
     </div>
   );

--- a/src/app/(main)/gatherings/loading.tsx
+++ b/src/app/(main)/gatherings/loading.tsx
@@ -5,7 +5,7 @@ import Loader from '@/app/components/Loader/Loader';
 const Loading = () => {
   return (
     <div className='flex min-h-screen items-center justify-center'>
-      <Loader />;
+      <Loader />
     </div>
   );
 };

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -5,7 +5,7 @@ import Loader from '@/app/components/Loader/Loader';
 const Loading = () => {
   return (
     <div className='flex min-h-screen items-center justify-center'>
-      <Loader />;
+      <Loader />
     </div>
   );
 };


### PR DESCRIPTION
## ✏️ 작업 내용
- 로그인 페이지 접근 시 아주 살짝 레이아웃 깨짐 현상이 있어 확인해 보니, loading 컴포넌트의 문제였습니다.
- (auth) 그룹은 page 컴포넌트 영역이 작은데, loading 에 일괄적으로 `min-h-vh` 클래스가 들어가 있어서 이를 수정했습니다.

## 📷 스크린샷
#### 기존 
![login-layoutshift](https://github.com/user-attachments/assets/b5d8cfca-d8c3-40bc-838e-390cf108a4a4)

#### 수정
![fixed-login](https://github.com/user-attachments/assets/ba2b4723-ffcf-4184-ac34-2411f3ba0580)

## ✍️ 사용법

## 🎸 기타
