### PR TITLE
fix: 지난 모임도 취소할 수 있는 기능 및 폰트 관련 에러 해결

### DIFF
--- a/src/app/components/BottomFloatingBar/ParticipationButton.tsx
+++ b/src/app/components/BottomFloatingBar/ParticipationButton.tsx
@@ -87,10 +87,11 @@ const ParticipationButton = ({
 
   // 주최자일 경우
   if (isHost) {
-    const disabled = isRegistrationEnded || isCancelled; // 마감일이 지났거나 취소되었을 경우 button 비활성화
+    const disabled = isRegistrationEnded; // 마감일이 지난 경우 버튼 비활성화
+
     return (
       <div className='flex w-[330px] gap-[10px]'>
-        {renderButton('취소하기', 'white', cancelGathering, disabled)}
+        {renderButton('취소하기', 'white', cancelGathering)}
         {renderButton('공유하기', 'default', copyUrlToClipboard, disabled)}
       </div>
     );

--- a/src/app/components/InformationCard/InformationCard.tsx
+++ b/src/app/components/InformationCard/InformationCard.tsx
@@ -158,7 +158,7 @@ const InformationCard = ({
         <div className='flex justify-between'>
           <div className='flex items-center'>
             <div className='text-14 font-semibold'>
-              모집 정원 {participantCount}명
+              현재 인원 {participantCount}명
             </div>
             <div className='ml-12 flex -space-x-6'>{renderAvatars()}</div>
           </div>
@@ -184,9 +184,9 @@ const InformationCard = ({
         />
 
         <div className='mt-10 flex justify-between text-12 font-semibold'>
-          <div>최소인원 {MIN_PARTICIPANTS}명</div>
+          <div>최소 인원 {MIN_PARTICIPANTS}명</div>
           <div className='text-var-orange-500'>
-            최대인원 {maxParticipants}명
+            최대 인원 {maxParticipants}명
           </div>
         </div>
       </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,78 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-@font-face {
-  font-family: 'Pretendard';
-  font-weight: 100;
-  font-style: normal;
-  src: url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Thin.woff')
-    format('woff');
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Pretendard';
-  font-weight: 200;
-  font-style: normal;
-  src: url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-ExtraLight.woff')
-    format('woff');
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Pretendard';
-  font-weight: 300;
-  font-style: normal;
-  src: url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Light.woff')
-    format('woff');
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Pretendard';
-  font-weight: 400;
-  font-style: normal;
-  src: url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Regular.woff')
-    format('woff');
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Pretendard';
-  font-weight: 500;
-  font-style: normal;
-  src: url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Medium.woff')
-    format('woff');
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Pretendard';
-  font-weight: 600;
-  font-style: normal;
-  src: url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-SemiBold.woff')
-    format('woff');
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Pretendard';
-  font-weight: 700;
-  font-style: normal;
-  src: url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Bold.woff')
-    format('woff');
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Pretendard';
-  font-weight: 800;
-  font-style: normal;
-  src: url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-ExtraBold.woff')
-    format('woff');
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Pretendard';
-  font-weight: 900;
-  font-style: normal;
-  src: url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Black.woff')
-    format('woff');
-  font-display: swap;
-}
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css');
 
 /* 사용자 정의 스크롤 바 숨기기 클래스 */
 .scrollbar-hide {


### PR DESCRIPTION
## ✏️ 작업 내용

- 지난 모임 취소 가능
- 폰트 불러올 때 에러 해결
- '모집 정원' => '현재 인원'으로 변경

## 📷 스크린샷

### 지난 모임 취소

https://github.com/user-attachments/assets/69029d9d-ea42-42ad-9048-3af879b1bbef

### '모집 정원' => '현재 인원'

<img width="522" alt="스크린샷 2024-10-10 15 08 18" src="https://github.com/user-attachments/assets/a611861f-9235-44a9-bd66-4cc835c75b07">

## ✍️ 사용법

## 🎸 기타
close #164 
### 지난 모임 공유 불가

지난 모임을 취소할 수는 있지만 공유할 수는 없도록 하였습니다!
