### PR TITLE
feat: 모임 남은 일자 수 태그로 표시

### DIFF
--- a/src/app/(main)/gatherings/[id]/_component/GatheringDetail.tsx
+++ b/src/app/(main)/gatherings/[id]/_component/GatheringDetail.tsx
@@ -26,6 +26,8 @@ const GatheringDetail = ({
   reviews,
   user,
 }: GatheringDetailProps) => {
+  console.log(gatheringInfo);
+
   const [currentPage, setCurrentPage] = useState<number>(1);
 
   const handlePageChange = (page: number) => {
@@ -38,7 +40,10 @@ const GatheringDetail = ({
         <div className='min-h-full bg-var-gray-50 px-16 pb-60 pt-24 md:px-24 md:pt-40 lg:px-100 dark:bg-neutral-900'>
           {/* 사진, Information Card */}
           <div className='flex flex-col items-center gap-y-16 md:flex md:flex-row md:gap-x-[14px] md:gap-y-0 lg:gap-x-24'>
-            <GatheringImage image={gatheringInfo.image} />
+            <GatheringImage
+              image={gatheringInfo.image}
+              endTime={gatheringInfo.registrationEnd}
+            />
             <GatheringInfo
               name={gatheringInfo.name || ''}
               location={gatheringInfo.location}

--- a/src/app/(main)/gatherings/[id]/_component/GatheringDetail.tsx
+++ b/src/app/(main)/gatherings/[id]/_component/GatheringDetail.tsx
@@ -26,8 +26,6 @@ const GatheringDetail = ({
   reviews,
   user,
 }: GatheringDetailProps) => {
-  console.log(gatheringInfo);
-
   const [currentPage, setCurrentPage] = useState<number>(1);
 
   const handlePageChange = (page: number) => {

--- a/src/app/(main)/gatherings/[id]/_component/GatheringImage.tsx
+++ b/src/app/(main)/gatherings/[id]/_component/GatheringImage.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 
 import { IconAlarm } from '@/public/icons';
-import { isSameDate } from '@/utils/formatDate';
+import getDaysUntilRegistrationEnd from '@/utils/getDaysUntilRegistrationEnd';
 
 interface GatheringImageProps {
   image: string;
@@ -9,6 +9,8 @@ interface GatheringImageProps {
 }
 
 const GatheringImage = ({ image, endTime }: GatheringImageProps) => {
+  const daysLeft = endTime ? getDaysUntilRegistrationEnd(endTime) : null;
+
   return (
     <div className='relative h-[270px] w-full md:w-[50vw] lg:max-w-[486px]'>
       <Image
@@ -19,10 +21,14 @@ const GatheringImage = ({ image, endTime }: GatheringImageProps) => {
         quality={85}
         sizes='(max-width: 768px) 100vw, (max-width: 1024px) 50vw'
       />
-      {endTime && isSameDate(endTime) && (
+      {daysLeft !== null && daysLeft <= 7 && (
         <div className='absolute right-0 top-0 flex items-center gap-4 rounded-bl-[12px] rounded-tr-[20px] bg-orange-600 py-2 pl-4 pr-6 text-xs font-medium text-var-white'>
           <IconAlarm width='24' height='24' />
-          <span className='text-12 font-semibold'>오늘 {endTime}시 마감</span>
+          {daysLeft === 0 ? (
+            <span className='text-12 font-semibold'>오늘 {endTime}시 마감</span>
+          ) : (
+            <span className='text-12 font-semibold'>{daysLeft}일 후 마감</span>
+          )}
         </div>
       )}
     </div>

--- a/src/app/(main)/gatherings/[id]/_component/GatheringImage.tsx
+++ b/src/app/(main)/gatherings/[id]/_component/GatheringImage.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 
 import { IconAlarm } from '@/public/icons';
 import getDaysUntilRegistrationEnd from '@/utils/getDaysUntilRegistrationEnd';
+import getTagMessage from '@/utils/getTagMessage';
 
 interface GatheringImageProps {
   image: string;
@@ -10,6 +11,7 @@ interface GatheringImageProps {
 
 const GatheringImage = ({ image, endTime }: GatheringImageProps) => {
   const daysLeft = endTime ? getDaysUntilRegistrationEnd(endTime) : null;
+  const tagMessage = getTagMessage(daysLeft, endTime);
 
   return (
     <div className='relative h-[270px] w-full md:w-[50vw] lg:max-w-[486px]'>
@@ -24,11 +26,7 @@ const GatheringImage = ({ image, endTime }: GatheringImageProps) => {
       {daysLeft !== null && daysLeft <= 7 && (
         <div className='absolute right-0 top-0 flex items-center gap-4 rounded-bl-[12px] rounded-tr-[20px] bg-orange-600 py-2 pl-4 pr-6 text-xs font-medium text-var-white'>
           <IconAlarm width='24' height='24' />
-          {daysLeft === 0 ? (
-            <span className='text-12 font-semibold'>오늘 {endTime}시 마감</span>
-          ) : (
-            <span className='text-12 font-semibold'>{daysLeft}일 후 마감</span>
-          )}
+          <span className='text-12 font-semibold'>{tagMessage}</span>
         </div>
       )}
     </div>

--- a/src/app/(main)/gatherings/page.tsx
+++ b/src/app/(main)/gatherings/page.tsx
@@ -6,8 +6,6 @@ import { getUserData } from '@/app/api/actions/mypage/getUserData';
 const GatheringsPage = async () => {
   const gatherings = await getGatherings({
     type: 'DALLAEMFIT',
-    sortBy: 'dateTime',
-    sortOrder: 'desc',
   });
   const userData = await getUserData();
 

--- a/src/app/api/actions/gatherings/getGatherings.ts
+++ b/src/app/api/actions/gatherings/getGatherings.ts
@@ -3,6 +3,7 @@
 import qs from 'qs';
 import { GatheringsType } from '@/types/client.type';
 import { GatheringType } from '@/types/data.type';
+import { LIMIT_PER_REQUEST } from '@/constants/common';
 
 interface GetGatheringsParams {
   id?: string;
@@ -20,7 +21,7 @@ const getGatherings = async (
   params: GetGatheringsParams = {},
 ): Promise<GatheringType[]> => {
   try {
-    const { limit = 10, offset = 0, ...rest } = params;
+    const { limit = LIMIT_PER_REQUEST, offset = 0, ...rest } = params;
 
     const queryString = qs.stringify(
       {

--- a/src/app/components/CardList/CardList.test.tsx
+++ b/src/app/components/CardList/CardList.test.tsx
@@ -77,8 +77,6 @@ describe('CardList Component', () => {
 describe('Tag Component Render', () => {
   const fixedDate = new Date('2024-10-15T00:00:00.000Z');
 
-  console.log(fixedDate);
-
   beforeAll(() => {
     jest.spyOn(global, 'Date').mockImplementation(() => fixedDate);
   });

--- a/src/app/components/CardList/CardList.test.tsx
+++ b/src/app/components/CardList/CardList.test.tsx
@@ -7,13 +7,15 @@ import { GatheringType } from '@/types/data.type';
 const date = new Date();
 date.setDate(date.getDate() + 3);
 
+const MOCK_FIXED_DATE = '2024-10-15T15:00:00.000Z';
+
 const MOCK_DATA_BASE: GatheringType = {
   teamId: 1,
   id: 1,
   type: 'test',
   name: '달램핏 오피스 스트레칭',
-  dateTime: date.toISOString(),
-  registrationEnd: date.toISOString(),
+  dateTime: MOCK_FIXED_DATE,
+  registrationEnd: MOCK_FIXED_DATE,
   location: 'test',
   participantCount: 10,
   capacity: 20,
@@ -45,7 +47,7 @@ jest.mock('@/public/icons', () => ({
 describe('CardList Component', () => {
   const MOCK_DATA = {
     ...MOCK_DATA_BASE,
-    dateTime: '2024-09-15T15:30:00',
+    dateTime: '2024-10-15T15:30:00',
   };
   it('should render Gatherings name', () => {
     render(<CardList data={MOCK_DATA} />);
@@ -55,7 +57,7 @@ describe('CardList Component', () => {
 
   it('should render `InfoChip` type `data`', () => {
     render(<CardList data={MOCK_DATA} />);
-    const dateChipElement = screen.getByText('9월 15일');
+    const dateChipElement = screen.getByText('10월 15일');
     expect(dateChipElement).toBeInTheDocument();
     expect(dateChipElement).toHaveClass('text-white');
   });

--- a/src/app/components/CardList/CardList.test.tsx
+++ b/src/app/components/CardList/CardList.test.tsx
@@ -75,24 +75,27 @@ describe('CardList Component', () => {
 
 // Tag 컴포넌트 렌더링 테스트 (isRenderTag)
 describe('Tag Component Render', () => {
-  it('should render Tag component when registrationEnd is same as today date', () => {
-    const date = new Date();
-    date.setHours(15, 0, 0, 0);
+  const fixedDate = new Date('2024-10-15T00:00:00.000Z');
 
+  console.log(fixedDate);
+
+  beforeAll(() => {
+    jest.spyOn(global, 'Date').mockImplementation(() => fixedDate);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should render Tag component when registrationEnd is same as today date', () => {
     const MOCK_DATA = {
       ...MOCK_DATA_BASE,
-      registrationEnd: date.toString(),
+      registrationEnd: '2024-10-15T15:00:00.000Z',
     };
 
     render(<CardList data={MOCK_DATA} />);
-    const tagElement = screen.getByText('오늘 15시 마감');
+    const tagElement = screen.getByText(/오늘 \d{1,2}시 마감/);
     expect(tagElement).toBeInTheDocument();
-  });
-
-  it('should NOT render Tag component when registrationEnd is NOT same as today date', () => {
-    render(<CardList data={MOCK_DATA_BASE} />);
-    const tagElement = screen.queryByText(/시 마감/);
-    expect(tagElement).not.toBeInTheDocument();
   });
 });
 

--- a/src/app/components/CardList/CardList.test.tsx
+++ b/src/app/components/CardList/CardList.test.tsx
@@ -4,9 +4,6 @@ import '@testing-library/jest-dom';
 import CardList from './CardList';
 import { GatheringType } from '@/types/data.type';
 
-const date = new Date();
-date.setDate(date.getDate() + 3);
-
 const MOCK_FIXED_DATE = '2024-10-15T15:00:00.000Z';
 
 const MOCK_DATA_BASE: GatheringType = {
@@ -84,7 +81,7 @@ describe('Tag Component Render', () => {
 
     const MOCK_DATA = {
       ...MOCK_DATA_BASE,
-      registrationEnd: date.toISOString(),
+      registrationEnd: date.toString(),
     };
 
     render(<CardList data={MOCK_DATA} />);

--- a/src/app/components/CardList/CardList.tsx
+++ b/src/app/components/CardList/CardList.tsx
@@ -1,23 +1,24 @@
 'use client';
 
+import { MouseEvent, useState } from 'react';
+import Image from 'next/image';
+
 import {
   IconSaveActive,
   IconSaveDiscard,
   IconSaveDiscardBtn,
   IconSaveInactive,
 } from '@/public/icons';
-import Image from 'next/image';
 import {
   formatDate,
   formatTimeColon,
   formatTimeHours,
-  isSameDate,
 } from '@/utils/formatDate';
+import getDaysUntilRegistrationEnd from '@/utils/getDaysUntilRegistrationEnd';
 import { GatheringType } from '@/types/data.type';
 import Tag from '@/app/components/Tag/Tag';
 import InfoChip from '@/app/components/Chip/InfoChip';
 import ProgressBar from '@/app/components/ProgressBar/ProgressBar';
-import { MouseEvent, useState } from 'react';
 
 // TODO : optional props를 필수로 변경
 interface CardProps {
@@ -27,8 +28,10 @@ interface CardProps {
 }
 
 const CardList = ({ data, isSaved, handleButtonClick }: CardProps) => {
+  const daysRemaining = getDaysUntilRegistrationEnd(data.registrationEnd);
+
   // 모임의 날짜와 현재 날짜를 비교하여 태그 렌더링
-  const isRenderTag = isSameDate(data.registrationEnd);
+  const isRenderTag = daysRemaining >= 0 && daysRemaining <= 7;
 
   // 모임의 날짜와 현재 날짜를 비교하여 마감 여부 표시
   const isChallengeEnded = new Date(data.dateTime) <= new Date();
@@ -63,7 +66,11 @@ const CardList = ({ data, isSaved, handleButtonClick }: CardProps) => {
           sizes='(max-width: 768px) 100vw, 280px'
         />
         {isRenderTag && (
-          <Tag>오늘 {formatTimeHours(data.registrationEnd)}시 마감</Tag>
+          <Tag>
+            {daysRemaining === 0
+              ? `오늘 ${formatTimeHours(data.registrationEnd)}시 마감`
+              : `${daysRemaining}일 후 마감`}
+          </Tag>
         )}
       </div>
 

--- a/src/app/components/Tag/Tag.tsx
+++ b/src/app/components/Tag/Tag.tsx
@@ -8,7 +8,7 @@ interface TagProps {
 const Tag = ({ children }: TagProps) => {
   return (
     <div
-      className={`absolute right-0 top-0 flex items-center gap-4 rounded-bl-[12px] rounded-tr-[22px] bg-orange-600 py-4 pl-8 pr-16 text-12 font-medium text-white md:rounded-none md:pr-[10px]`}
+      className={`absolute right-0 top-0 flex items-center gap-4 rounded-bl-[12px] rounded-tr-[22px] bg-orange-600 py-4 pl-8 pr-16 text-12 font-medium text-white md:rounded-tr-none md:pr-[10px]`}
     >
       <IconAlarm width='24' height='24' />
       <span className='shrink-0'>{children}</span>

--- a/src/hooks/useGatherings.ts
+++ b/src/hooks/useGatherings.ts
@@ -30,7 +30,7 @@ const useGatherings = (initialGatherings: GatheringType[]) => {
   );
   const [selectedChip, setSelectedChip] = useState<GatheringChipsType>('ALL');
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const [sortOption, setSortOption] = useState<string | undefined>('dateTime');
+  const [sortOption, setSortOption] = useState<string | undefined>();
   const [offset, setOffset] = useState<number>(0);
 
   // 필터링된 모임 데이터를 가져오는 훅

--- a/src/utils/getDaysUntilRegistrationEnd.ts
+++ b/src/utils/getDaysUntilRegistrationEnd.ts
@@ -1,0 +1,14 @@
+const getDaysUntilRegistrationEnd = (registrationEnd: string) => {
+  const today = new Date();
+  const endDate = new Date(registrationEnd);
+
+  // 두 날짜의 차이를 밀리초로 계산
+  const timeDifference = endDate.getTime() - today.getTime();
+
+  // 밀리초를 일 수로 변환 (하루 = 24 * 60 * 60 * 1000)
+  const daysRemaining = Math.ceil(timeDifference / (1000 * 60 * 60 * 24));
+
+  return daysRemaining;
+};
+
+export default getDaysUntilRegistrationEnd;

--- a/src/utils/getTagMessage.ts
+++ b/src/utils/getTagMessage.ts
@@ -1,0 +1,13 @@
+const getTagMessage = (daysLeft: number | null, endTime?: string) => {
+  if (daysLeft === null) return '';
+
+  if (daysLeft < 0) {
+    return '마감된 모임입니다.';
+  } else if (daysLeft === 0) {
+    return `오늘 ${endTime}시 마감`;
+  } else {
+    return `${daysLeft}일 후 마감`;
+  }
+};
+
+export default getTagMessage;


### PR DESCRIPTION
## ✏️ 작업 내용

- 남은 일자가 일주일 이내인 경우 태그로 표시하는 기능 구현
- 필터링 시 첫 화면에서는 모임이 생성된 순서대로 나오도록 변경 => (여기서 마감된 모임들 관련한 이슈 발생)

## 📷 스크린샷

### /gatherings

<img width="976" alt="스크린샷 2024-10-14 15 02 36" src="https://github.com/user-attachments/assets/d751ec82-77f6-4d9a-b38f-bac43db8d76b">

### /gatherings/[id]

<img width="964" alt="스크린샷 2024-10-14 15 08 46" src="https://github.com/user-attachments/assets/db778f03-2c9f-425c-8912-4162c6aa857e">

## 스타일 수정

### Tag 에 border radius 추가

<img width="1026" alt="스크린샷 2024-10-15 09 25 51" src="https://github.com/user-attachments/assets/e1af550f-044e-432a-9a71-1abade688bb7">


## ✍️ 사용법

## 🎸 기타

### 마감된 모임이 먼저 보이는 이슈

클라이언트에서 구현해 보려고 했는데, 너무 비효율적으로 요청하는 것 같아서 일단 두었습니다..!
서버에서 필터링된 데이터를 받을 수 있게 된다면 바로 수정하도록 하겠습니다!
