### PR TITLE
refactor: QueryKey Factory pattern 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
+        "@tanstack/react-query-devtools": "^5.59.13",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
         "@types/jest": "^29.5.12",
@@ -3308,26 +3309,53 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.54.1.tgz",
-      "integrity": "sha512-hKS+WRpT5zBFip21pB6Jx1C0hranWQrbv5EJ7qPoiV5MYI3C8rTCqWC9DdBseiPT1JgQWh8Y55YthuYZNiw3Xw==",
+      "version": "5.59.13",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.59.13.tgz",
+      "integrity": "sha512-Oou0bBu/P8+oYjXsJQ11j+gcpLAMpqW42UlokQYEz4dE7+hOtVO9rVuolJKgEccqzvyFzqX4/zZWY+R/v1wVsQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.58.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.58.0.tgz",
+      "integrity": "sha512-iFdQEFXaYYxqgrv63ots+65FGI+tNp5ZS5PdMU1DWisxk3fez5HG3FyVlbUva+RdYS5hSLbxZ9aw3yEs97GNTw==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.54.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.54.1.tgz",
-      "integrity": "sha512-SuMi4JBYv49UtmiRyqjxY7XAnE1qwLht9nlkC8sioxFXz5Uzj30lepiKf2mYXuXfC7fHYjTrAPkNx+427pRHXA==",
+      "version": "5.59.13",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.59.13.tgz",
+      "integrity": "sha512-GB2ELtiH8tL0rcFiM4sWvnXhazt1xRXX/LolMEV12kfEKu58aNA4lQoieslP61PO4vZO9JJMwm+6lqyS0E1HOA==",
       "dependencies": {
-        "@tanstack/query-core": "5.54.1"
+        "@tanstack/query-core": "5.59.13"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.59.13",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.59.13.tgz",
+      "integrity": "sha512-6RW9jjJPeIUxu/rAy7W2a4cCOFp46Tv2LY2pOS4m5s8vqOSvI8dkizvOq+GmLGtI2E+QjoeZbEOGKDSmqDynWg==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/query-devtools": "5.58.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.59.13",
         "react": "^18 || ^19"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
+        "@lukemorales/query-key-factory": "^1.3.4",
         "@tanstack/react-query": "^5.54.1",
         "next": "14.2.7",
         "next-themes": "^0.3.0",
@@ -2782,6 +2783,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukemorales/query-key-factory": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lukemorales/query-key-factory/-/query-key-factory-1.3.4.tgz",
+      "integrity": "sha512-A3frRDdkmaNNQi6mxIshsDk4chRXWoXa05US8fBo4kci/H+lVmujS6QrwQLLGIkNIRFGjMqp2uKjC4XsLdydRw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@tanstack/query-core": ">= 4.0.0",
+        "@tanstack/react-query": ">= 4.0.0"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",
+    "@tanstack/react-query-devtools": "^5.59.13",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
     "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
+    "@lukemorales/query-key-factory": "^1.3.4",
     "@tanstack/react-query": "^5.54.1",
     "next": "14.2.7",
     "next-themes": "^0.3.0",

--- a/src/app/(main)/mypage/_component/MyGatheringList.tsx
+++ b/src/app/(main)/mypage/_component/MyGatheringList.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import getMyGathergins from '@/app/api/gatherings/service/getMyGathergins';
+import getMyGatherings from '@/app/api/gatherings/service/getMyGatherings';
 import Card from '@/app/components/Card/Card';
 import InfiniteScroll from '@/app/components/InfiniteScroll/InfiniteScroll';
 import ReviewModal from '@/app/components/Modal/ReviewModal';
-import { useState } from 'react';
-import { UserJoinedGatheringsData } from '@/types/data.type';
 import useParticipation from '@/hooks/useParticipation';
 import { UserData } from '@/types/client.type';
+import { UserJoinedGatheringsData } from '@/types/data.type';
+import { useState } from 'react';
 
 interface MyGatheringListProps {
   user: UserData | null;
@@ -33,7 +33,7 @@ const MyGatheringList = ({ initData, user }: MyGatheringListProps) => {
       <InfiniteScroll
         initData={initData}
         queryKey={['myGatherings']}
-        queryFn={getMyGathergins}
+        queryFn={getMyGatherings}
         emptyText='아직 참여한 모임이 없습니다.'
         errorText='모임을 불러오지 못했습니다.'
         renderItem={(item, index) => (

--- a/src/app/(main)/mypage/_component/MyGatheringList.tsx
+++ b/src/app/(main)/mypage/_component/MyGatheringList.tsx
@@ -33,7 +33,7 @@ const MyGatheringList = ({ initData, user }: MyGatheringListProps) => {
     <>
       <InfiniteScroll
         initData={initData}
-        queryKey={joinedKeys}
+        queryKey={joinedKeys.detail}
         queryFn={getMyGatherings}
         emptyText='아직 참여한 모임이 없습니다.'
         errorText='모임을 불러오지 못했습니다.'
@@ -45,7 +45,7 @@ const MyGatheringList = ({ initData, user }: MyGatheringListProps) => {
               handleButtonClick={() => {
                 item.isCompleted
                   ? handleOpenModal(item.id)
-                  : handleWithdrawClickWithId(item.id, joinedKeys);
+                  : handleWithdrawClickWithId(item.id, joinedKeys.detail);
               }}
             />
           </Card>

--- a/src/app/(main)/mypage/_component/MyGatheringList.tsx
+++ b/src/app/(main)/mypage/_component/MyGatheringList.tsx
@@ -5,7 +5,7 @@ import Card from '@/app/components/Card/Card';
 import InfiniteScroll from '@/app/components/InfiniteScroll/InfiniteScroll';
 import ReviewModal from '@/app/components/Modal/ReviewModal';
 import useParticipation from '@/hooks/useParticipation';
-import { joinedKeys } from '@/queries/mypage/joined';
+import { queries } from '@/queries';
 import { UserData } from '@/types/client.type';
 import { UserJoinedGatheringsData } from '@/types/data.type';
 import { useState } from 'react';
@@ -33,7 +33,7 @@ const MyGatheringList = ({ initData, user }: MyGatheringListProps) => {
     <>
       <InfiniteScroll
         initData={initData}
-        queryKey={joinedKeys._def}
+        queryKey={queries.joined._def}
         queryFn={getMyGatherings}
         emptyText='아직 참여한 모임이 없습니다.'
         errorText='모임을 불러오지 못했습니다.'
@@ -45,7 +45,7 @@ const MyGatheringList = ({ initData, user }: MyGatheringListProps) => {
               handleButtonClick={() => {
                 item.isCompleted
                   ? handleOpenModal(item.id)
-                  : handleWithdrawClickWithId(item.id, joinedKeys._def);
+                  : handleWithdrawClickWithId(item.id, queries.joined._def);
               }}
             />
           </Card>

--- a/src/app/(main)/mypage/_component/MyGatheringList.tsx
+++ b/src/app/(main)/mypage/_component/MyGatheringList.tsx
@@ -5,6 +5,7 @@ import Card from '@/app/components/Card/Card';
 import InfiniteScroll from '@/app/components/InfiniteScroll/InfiniteScroll';
 import ReviewModal from '@/app/components/Modal/ReviewModal';
 import useParticipation from '@/hooks/useParticipation';
+import { joinedKeys } from '@/queries/mypage/joined';
 import { UserData } from '@/types/client.type';
 import { UserJoinedGatheringsData } from '@/types/data.type';
 import { useState } from 'react';
@@ -32,11 +33,11 @@ const MyGatheringList = ({ initData, user }: MyGatheringListProps) => {
     <>
       <InfiniteScroll
         initData={initData}
-        queryKey={['myGatherings']}
+        queryKey={joinedKeys}
         queryFn={getMyGatherings}
         emptyText='아직 참여한 모임이 없습니다.'
         errorText='모임을 불러오지 못했습니다.'
-        renderItem={(item, index) => (
+        renderItem={(item) => (
           <Card data={item}>
             <Card.Chips />
             <Card.Info />
@@ -44,7 +45,7 @@ const MyGatheringList = ({ initData, user }: MyGatheringListProps) => {
               handleButtonClick={() => {
                 item.isCompleted
                   ? handleOpenModal(item.id)
-                  : handleWithdrawClickWithId(item.id, ['myGatherings']);
+                  : handleWithdrawClickWithId(item.id, joinedKeys);
               }}
             />
           </Card>

--- a/src/app/(main)/mypage/_component/MyGatheringList.tsx
+++ b/src/app/(main)/mypage/_component/MyGatheringList.tsx
@@ -33,7 +33,7 @@ const MyGatheringList = ({ initData, user }: MyGatheringListProps) => {
     <>
       <InfiniteScroll
         initData={initData}
-        queryKey={joinedKeys.detail}
+        queryKey={joinedKeys._def}
         queryFn={getMyGatherings}
         emptyText='아직 참여한 모임이 없습니다.'
         errorText='모임을 불러오지 못했습니다.'
@@ -45,7 +45,7 @@ const MyGatheringList = ({ initData, user }: MyGatheringListProps) => {
               handleButtonClick={() => {
                 item.isCompleted
                   ? handleOpenModal(item.id)
-                  : handleWithdrawClickWithId(item.id, joinedKeys.detail);
+                  : handleWithdrawClickWithId(item.id, joinedKeys._def);
               }}
             />
           </Card>

--- a/src/app/(main)/mypage/review/writable/page.tsx
+++ b/src/app/(main)/mypage/review/writable/page.tsx
@@ -4,18 +4,18 @@ import getJoinedGatherings from '@/app/api/actions/gatherings/getJoinedGathering
 import Card from '@/app/components/Card/Card';
 import ReviewModal from '@/app/components/Modal/ReviewModal';
 import usePreventScroll from '@/hooks/usePreventScroll';
-import { writableReviewKeys } from '@/queries/mypage/writableReview';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import EmptyReviewPage from '../../_component/EmptyReviewPage';
 import ReviewFilterTab from '../../_component/ReviewFilterTab';
+import { queries } from '@/queries';
 
 const WritableReviewsPage = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [cardId, setCardId] = useState<number>(0);
 
   const { data: writableReviews } = useQuery({
-    ...writableReviewKeys.all(),
+    ...queries.writableReview.all(),
     queryFn: () => getJoinedGatherings({ completed: true, reviewed: false }),
   });
 

--- a/src/app/(main)/mypage/review/writable/page.tsx
+++ b/src/app/(main)/mypage/review/writable/page.tsx
@@ -15,7 +15,7 @@ const WritableReviewsPage = () => {
   const [cardId, setCardId] = useState<number>(0);
 
   const { data: writableReviews } = useQuery({
-    ...writableReviewKeys.writable(),
+    ...writableReviewKeys.all(),
     queryFn: () => getJoinedGatherings({ completed: true, reviewed: false }),
   });
 

--- a/src/app/(main)/mypage/review/writable/page.tsx
+++ b/src/app/(main)/mypage/review/writable/page.tsx
@@ -4,6 +4,7 @@ import getJoinedGatherings from '@/app/api/actions/gatherings/getJoinedGathering
 import Card from '@/app/components/Card/Card';
 import ReviewModal from '@/app/components/Modal/ReviewModal';
 import usePreventScroll from '@/hooks/usePreventScroll';
+import { writableReviewKeys } from '@/queries/mypage/writableReview';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import EmptyReviewPage from '../../_component/EmptyReviewPage';
@@ -14,7 +15,7 @@ const WritableReviewsPage = () => {
   const [cardId, setCardId] = useState<number>(0);
 
   const { data: writableReviews } = useQuery({
-    queryKey: ['reviews', 'writable'],
+    ...writableReviewKeys.writable(),
     queryFn: () => getJoinedGatherings({ completed: true, reviewed: false }),
   });
 

--- a/src/app/api/gatherings/service/getMyGatherings.ts
+++ b/src/app/api/gatherings/service/getMyGatherings.ts
@@ -6,7 +6,7 @@ import {
 } from '@/constants/common';
 import { FetchGatheringsResponse } from '@/types/data.type';
 
-const getMyGathergins = async (
+const getMyGatherings = async (
   offset = DEFAULT_GATHERINGS_OFFSET,
   limit = DEFAULT_GATHERINGS_LIMIT,
 ): Promise<FetchGatheringsResponse> => {
@@ -20,4 +20,4 @@ const getMyGathergins = async (
   return response.json();
 };
 
-export default getMyGathergins;
+export default getMyGatherings;

--- a/src/app/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/src/app/components/InfiniteScroll/InfiniteScroll.tsx
@@ -18,7 +18,7 @@ interface InfiniteQueryResponse<T extends ItemWithId> {
 
 interface InfiniteScrollProps<T extends ItemWithId> {
   initData: T[];
-  queryKey: any;
+  queryKey: readonly string[];
   queryFn: (offset?: number) => Promise<InfiniteQueryResponse<T>>;
   limit?: number;
   emptyText: string;

--- a/src/app/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/src/app/components/InfiniteScroll/InfiniteScroll.tsx
@@ -18,7 +18,7 @@ interface InfiniteQueryResponse<T extends ItemWithId> {
 
 interface InfiniteScrollProps<T extends ItemWithId> {
   initData: T[];
-  queryKey: string[];
+  queryKey: any;
   queryFn: (offset?: number) => Promise<InfiniteQueryResponse<T>>;
   limit?: number;
   emptyText: string;

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { SavedGatheringProvider } from '@/context/SavedGatheringContext';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ReactNode } from 'react';
 import { UserProvider } from './(auth)/context/UserContext';
 import { ThemeProvider } from './theme-provider';
@@ -46,6 +47,7 @@ export default function Providers({ children }: { children: ReactNode }) {
         <SavedGatheringProvider>
           <QueryClientProvider client={queryClient}>
             {children}
+            <ReactQueryDevtools initialIsOpen={false} />
           </QueryClientProvider>
         </SavedGatheringProvider>
       </UserProvider>

--- a/src/hooks/useParticipation.ts
+++ b/src/hooks/useParticipation.ts
@@ -50,7 +50,7 @@ export default function useParticipation(user: UserData | null) {
     }
   };
 
-  const handleWithdrawClickWithId = async (id: number, queryKey: string[]) => {
+  const handleWithdrawClickWithId = async (id: number, queryKey: any) => {
     const { success, message } = await deleteGatheringToWithdraw(id);
 
     if (!success) {
@@ -58,7 +58,7 @@ export default function useParticipation(user: UserData | null) {
       return;
     }
     // 쿼리 무효화 함수
-    await queryClient.invalidateQueries({ queryKey }); // querykey 무효화시켜서 취소한 모임 반영하여 최신화
+    await queryClient.invalidateQueries(queryKey); // querykey 무효화시켜서 취소한 모임 반영하여 최신화
 
     toast.success(message);
     setHasParticipated(false);

--- a/src/hooks/useParticipation.ts
+++ b/src/hooks/useParticipation.ts
@@ -50,7 +50,10 @@ export default function useParticipation(user: UserData | null) {
     }
   };
 
-  const handleWithdrawClickWithId = async (id: number, queryKey: any) => {
+  const handleWithdrawClickWithId = async (
+    id: number,
+    queryKey: readonly string[],
+  ) => {
     const { success, message } = await deleteGatheringToWithdraw(id);
 
     if (!success) {
@@ -58,7 +61,7 @@ export default function useParticipation(user: UserData | null) {
       return;
     }
     // 쿼리 무효화 함수
-    await queryClient.invalidateQueries(queryKey); // querykey 무효화시켜서 취소한 모임 반영하여 최신화
+    await queryClient.invalidateQueries({ queryKey }); // querykey 무효화시켜서 취소한 모임 반영하여 최신화
 
     toast.success(message);
     setHasParticipated(false);

--- a/src/hooks/useReviews/buildParams.ts
+++ b/src/hooks/useReviews/buildParams.ts
@@ -1,13 +1,7 @@
 import { REVIEW_SORT_OPTIONS_MAP } from '@/constants/common';
-import { GatheringsType } from '@/types/client.type';
+import { FilteringOptionsType, GatheringsType } from '@/types/client.type';
 import { GetReviewsParams } from '@/types/data.type';
 import { formatCalendarDate } from '@/utils/formatDate';
-
-interface FilteringOptionsType {
-  location: string | undefined;
-  date: Date | null;
-  sortOption: string | undefined;
-}
 
 const buildParams = (
   type: GatheringsType,

--- a/src/hooks/useReviews/useFilterState.ts
+++ b/src/hooks/useReviews/useFilterState.ts
@@ -1,11 +1,9 @@
-import { GatheringChipsType, GatheringTabsType } from '@/types/client.type';
+import {
+  FilteringOptionsType,
+  GatheringChipsType,
+  GatheringTabsType,
+} from '@/types/client.type';
 import { useState } from 'react';
-
-interface FilteringOptionsType {
-  location: string | undefined;
-  date: Date | null;
-  sortOption: string | undefined;
-}
 
 const useFilterState = () => {
   const [activeTab, setActiveTab] = useState<GatheringTabsType>('DALLAEMFIT');

--- a/src/hooks/useReviews/useReveiws.ts
+++ b/src/hooks/useReviews/useReveiws.ts
@@ -1,14 +1,14 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import getReviewList from '@/app/api/actions/reviews/getReviewList';
 import getReviewScore from '@/app/api/actions/reviews/getReviewScore';
-import useFilterState from './useFilterState';
-import buildParams from './buildParams';
-import { ReviewScoreType, ReviewsType } from '@/types/data.type';
 import {
   DEFAULT_GATHERINGS_OFFSET,
   LIMIT_PER_REQUEST,
 } from '@/constants/common';
-import { reviewKeys } from '@/queries/review/review';
+import { queries } from '@/queries';
+import { ReviewScoreType, ReviewsType } from '@/types/data.type';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import buildParams from './buildParams';
+import useFilterState from './useFilterState';
 
 const useReviews = (
   initialReviewsData: ReviewsType[],
@@ -35,7 +35,7 @@ const useReviews = (
     isError: isScoreError,
     error: scoreError,
   } = useQuery({
-    ...reviewKeys.score(activeTab, selectedChip),
+    ...queries.reviews.score(activeTab, selectedChip),
     queryFn: async () => {
       try {
         const type = selectedChip === 'ALL' ? activeTab : selectedChip;
@@ -59,7 +59,7 @@ const useReviews = (
     isError: isReviewsError,
     error: reviewsError,
   } = useInfiniteQuery({
-    ...reviewKeys.detail(activeTab, selectedChip, filteringOptions),
+    ...queries.reviews.detail(activeTab, selectedChip, filteringOptions),
     queryFn: async ({ pageParam = DEFAULT_GATHERINGS_OFFSET }) => {
       try {
         const params = getParams();

--- a/src/hooks/useReviews/useReveiws.ts
+++ b/src/hooks/useReviews/useReveiws.ts
@@ -1,5 +1,4 @@
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
 import getReviewList from '@/app/api/actions/reviews/getReviewList';
 import getReviewScore from '@/app/api/actions/reviews/getReviewScore';
 import useFilterState from './useFilterState';
@@ -9,6 +8,7 @@ import {
   DEFAULT_GATHERINGS_OFFSET,
   LIMIT_PER_REQUEST,
 } from '@/constants/common';
+import { reviewKeys } from '@/queries/review/review';
 
 const useReviews = (
   initialReviewsData: ReviewsType[],
@@ -35,7 +35,8 @@ const useReviews = (
     isError: isScoreError,
     error: scoreError,
   } = useQuery({
-    queryKey: ['score', activeTab, selectedChip],
+    // queryKey: ['score', activeTab, selectedChip],
+    ...reviewKeys.score(activeTab, selectedChip),
     queryFn: async () => {
       try {
         const type = selectedChip === 'ALL' ? activeTab : selectedChip;
@@ -59,7 +60,7 @@ const useReviews = (
     isError: isReviewsError,
     error: reviewsError,
   } = useInfiniteQuery({
-    queryKey: ['reviews', filteringOptions, activeTab, selectedChip],
+    ...reviewKeys.detail(activeTab, selectedChip, filteringOptions),
     queryFn: async ({ pageParam = DEFAULT_GATHERINGS_OFFSET }) => {
       try {
         const params = getParams();

--- a/src/hooks/useReviews/useReveiws.ts
+++ b/src/hooks/useReviews/useReveiws.ts
@@ -35,7 +35,6 @@ const useReviews = (
     isError: isScoreError,
     error: scoreError,
   } = useQuery({
-    // queryKey: ['score', activeTab, selectedChip],
     ...reviewKeys.score(activeTab, selectedChip),
     queryFn: async () => {
       try {

--- a/src/hooks/useUserCreated.ts
+++ b/src/hooks/useUserCreated.ts
@@ -1,11 +1,12 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
 import getGatherings from '@/app/api/actions/gatherings/getGatherings';
-import { GatheringType } from '@/types/data.type';
 import {
   DEFAULT_GATHERINGS_OFFSET,
   LIMIT_PER_REQUEST,
   SORT_OPTIONS_MAP,
 } from '@/constants/common';
+import { createdKeys } from '@/queries/mypage/created';
+import { GatheringType } from '@/types/data.type';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 export const useUserCreated = (
   initialGatheringList: GatheringType[],
@@ -19,7 +20,7 @@ export const useUserCreated = (
     isError,
     error,
   } = useInfiniteQuery({
-    queryKey: ['created', createdBy],
+    ...createdKeys.detail(createdBy),
     queryFn: async ({ pageParam = DEFAULT_GATHERINGS_OFFSET }) => {
       try {
         const response = await getGatherings({

--- a/src/hooks/useUserCreated.ts
+++ b/src/hooks/useUserCreated.ts
@@ -4,7 +4,7 @@ import {
   LIMIT_PER_REQUEST,
   SORT_OPTIONS_MAP,
 } from '@/constants/common';
-import { createdKeys } from '@/queries/mypage/created';
+import { queries } from '@/queries';
 import { GatheringType } from '@/types/data.type';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
@@ -20,7 +20,7 @@ export const useUserCreated = (
     isError,
     error,
   } = useInfiniteQuery({
-    ...createdKeys.detail(createdBy),
+    ...queries.created.detail(createdBy),
     queryFn: async ({ pageParam = DEFAULT_GATHERINGS_OFFSET }) => {
       try {
         const response = await getGatherings({

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,0 +1,7 @@
+import { mergeQueryKeys } from '@lukemorales/query-key-factory';
+import { created } from './mypage/created';
+import { joined } from './mypage/joined';
+import { writableReview } from './mypage/writableReview';
+import { reviews } from './review/review';
+
+export const queries = mergeQueryKeys(created, reviews, joined, writableReview);

--- a/src/queries/mypage/created.ts
+++ b/src/queries/mypage/created.ts
@@ -4,5 +4,5 @@ import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 export const createdKeys = createQueryKeys('created', {
   all: null,
-  detail: (createdBy: string) => ['detail', createdBy],
+  detail: (createdBy: string) => ({ queryKey: ['detail', createdBy] }),
 });

--- a/src/queries/mypage/created.ts
+++ b/src/queries/mypage/created.ts
@@ -4,5 +4,5 @@ import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 export const createdKeys = createQueryKeys('created', {
   all: null,
-  detail: (createdBy: string) => ({ queryKey: ['detail', createdBy] }),
+  detail: (createdBy: string) => ({ queryKey: [createdBy] }),
 });

--- a/src/queries/mypage/created.ts
+++ b/src/queries/mypage/created.ts
@@ -1,3 +1,5 @@
+// 마이 페이지 - 내가 만든 모임
+
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 export const createdKeys = createQueryKeys('created', {

--- a/src/queries/mypage/created.ts
+++ b/src/queries/mypage/created.ts
@@ -2,7 +2,7 @@
 
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
-export const createdKeys = createQueryKeys('created', {
+export const created = createQueryKeys('created', {
   all: null,
   detail: (createdBy: string) => ({ queryKey: [createdBy] }),
 });

--- a/src/queries/mypage/created.ts
+++ b/src/queries/mypage/created.ts
@@ -1,0 +1,6 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+export const createdKeys = createQueryKeys('created', {
+  all: null,
+  detail: (createdBy: string) => ['detail', createdBy],
+});

--- a/src/queries/mypage/joined.ts
+++ b/src/queries/mypage/joined.ts
@@ -2,6 +2,6 @@
 
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
-export const joinedKeys = createQueryKeys('joined', {
+export const joined = createQueryKeys('joined', {
   all: null,
 });

--- a/src/queries/mypage/joined.ts
+++ b/src/queries/mypage/joined.ts
@@ -3,5 +3,5 @@
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 export const joinedKeys = createQueryKeys('joined', {
-  detail: () => ({ queryKey: ['detail'] }),
+  all: null,
 });

--- a/src/queries/mypage/joined.ts
+++ b/src/queries/mypage/joined.ts
@@ -1,0 +1,7 @@
+// 마이페이지 - 나의 모임
+
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+export const joinedKeys = createQueryKeys('joined', {
+  all: null,
+});

--- a/src/queries/mypage/joined.ts
+++ b/src/queries/mypage/joined.ts
@@ -3,5 +3,5 @@
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 export const joinedKeys = createQueryKeys('joined', {
-  all: null,
+  detail: () => ({ queryKey: ['detail'] }),
 });

--- a/src/queries/mypage/writableReview.ts
+++ b/src/queries/mypage/writableReview.ts
@@ -2,6 +2,6 @@
 
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
-export const writableReviewKeys = createQueryKeys('reviews', {
+export const writableReview = createQueryKeys('writableReview', {
   all: () => ({ queryKey: ['writable'] }),
 });

--- a/src/queries/mypage/writableReview.ts
+++ b/src/queries/mypage/writableReview.ts
@@ -1,0 +1,8 @@
+// 마이페이지 - 나의 리뷰 - 작성 가능한 리뷰
+
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+export const writableReviewKeys = createQueryKeys('reviews', {
+  all: null,
+  writable: () => ({ queryKey: ['writable'] }),
+});

--- a/src/queries/mypage/writableReview.ts
+++ b/src/queries/mypage/writableReview.ts
@@ -3,6 +3,5 @@
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 export const writableReviewKeys = createQueryKeys('reviews', {
-  all: null,
-  writable: () => ({ queryKey: ['writable'] }),
+  all: () => ({ queryKey: ['writable'] }),
 });

--- a/src/queries/review/review.ts
+++ b/src/queries/review/review.ts
@@ -1,0 +1,20 @@
+import {
+  FilteringOptionsType,
+  GatheringChipsType,
+  GatheringTabsType,
+} from '@/types/client.type';
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+export const reviewKeys = createQueryKeys('reviews', {
+  all: null,
+  score: (activeTab: GatheringTabsType, selectedChip: GatheringChipsType) => [
+    'score',
+    activeTab,
+    selectedChip,
+  ],
+  detail: (
+    activeTab: GatheringTabsType,
+    selectedChip: GatheringChipsType,
+    filteringOptions: FilteringOptionsType,
+  ) => ['detail', activeTab, selectedChip, filteringOptions],
+});

--- a/src/queries/review/review.ts
+++ b/src/queries/review/review.ts
@@ -9,14 +9,12 @@ import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 export const reviewKeys = createQueryKeys('reviews', {
   all: null,
-  score: (activeTab: GatheringTabsType, selectedChip: GatheringChipsType) => [
-    'score',
-    activeTab,
-    selectedChip,
-  ],
+  score: (activeTab: GatheringTabsType, selectedChip: GatheringChipsType) => ({
+    queryKey: ['score', activeTab, selectedChip],
+  }),
   detail: (
     activeTab: GatheringTabsType,
     selectedChip: GatheringChipsType,
     filteringOptions: FilteringOptionsType,
-  ) => ['detail', activeTab, selectedChip, filteringOptions],
+  ) => ({ queryKey: ['detail', activeTab, selectedChip, filteringOptions] }),
 });

--- a/src/queries/review/review.ts
+++ b/src/queries/review/review.ts
@@ -7,7 +7,7 @@ import {
 } from '@/types/client.type';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
-export const reviewKeys = createQueryKeys('reviews', {
+export const reviews = createQueryKeys('reviews', {
   all: null,
   score: (activeTab: GatheringTabsType, selectedChip: GatheringChipsType) => ({
     queryKey: [activeTab, selectedChip],

--- a/src/queries/review/review.ts
+++ b/src/queries/review/review.ts
@@ -10,11 +10,11 @@ import { createQueryKeys } from '@lukemorales/query-key-factory';
 export const reviewKeys = createQueryKeys('reviews', {
   all: null,
   score: (activeTab: GatheringTabsType, selectedChip: GatheringChipsType) => ({
-    queryKey: ['score', activeTab, selectedChip],
+    queryKey: [activeTab, selectedChip],
   }),
   detail: (
     activeTab: GatheringTabsType,
     selectedChip: GatheringChipsType,
     filteringOptions: FilteringOptionsType,
-  ) => ({ queryKey: ['detail', activeTab, selectedChip, filteringOptions] }),
+  ) => ({ queryKey: [activeTab, selectedChip, filteringOptions] }),
 });

--- a/src/queries/review/review.ts
+++ b/src/queries/review/review.ts
@@ -1,3 +1,5 @@
+// 모든 리뷰 페이지
+
 import {
   FilteringOptionsType,
   GatheringChipsType,

--- a/src/types/client.type.ts
+++ b/src/types/client.type.ts
@@ -33,3 +33,9 @@ export type GatheringFilters = Partial<{
   sortOrder: 'asc' | 'desc';
   offset: number;
 }>;
+
+export interface FilteringOptionsType {
+  location: string | undefined;
+  date: Date | null;
+  sortOption: string | undefined;
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- 쿼리 키 팩토리 라이브러리 설치
- 쿼리 키 팩토리 패턴 적용
- react-query devtools 설치
- 기타) 오타인 파일 발견해서 올바르게 변경

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/49e2c2ca-a7e7-491a-90fc-2ac2e06c2680)


## ✍️ 사용법
### 실제 사용예시
```ts
import { createQueryKeys } from '@lukemorales/query-key-factory'; // 쿼리 키 생성해주는 함수 

// 리뷰에 관한 쿼리 키 생성
export const reviewKeys = createQueryKeys('reviews', {
  all: null,
  // score에 관한 queryKey가 담긴 객체 생성하기
  // 인자로 넘길려면 이렇게 화살표 함수 이용하기
  score: (activeTab: GatheringTabsType, selectedChip: GatheringChipsType) => ({
    queryKey: [activeTab, selectedChip],
  }),
  // detail에 관한 queryKey가 담긴 객체 생성하기
  detail: (
    activeTab: GatheringTabsType,
    selectedChip: GatheringChipsType,
    filteringOptions: FilteringOptionsType,
  ) => ({ queryKey: [activeTab, selectedChip, filteringOptions] }),
});
```

```js
const {
  data: score,
  isError: isScoreError,
  error: scoreError,
} = useQuery({
  // 스프레드 연산자로 queryKey 객체 풀기
  ...reviewKeys.score(activeTab, selectedChip),
  queryFn: async () => {
    try {
      const type = selectedChip === 'ALL' ? activeTab : selectedChip;
      const response = await getReviewScore({ type: type });
      return response;
    } catch (error) {
      throw error instanceof Error
        ? new Error(error.message)
        : new Error('리뷰 평점을 불러오는 중 오류가 발생했습니다.');
    }
  },
  initialData: reviewScoreData,
});
```
### 추가 설명
`._def`, `._ctx`를 사용해서 구체적인 값을 가져올 수 있습니다.
`._def`는 createQueryKeys 함수의 첫 번째 인자를 가져옵니다. (기본값이라고 생각하면 편해요)

## 🎸 기타
[라이브러리 링크 참고](https://github.com/lukemorales/query-key-factory)
[적용 사례 블로그](https://velog.io/@bo-like-chicken/Query-Keys%EB%A5%BC-%EA%B4%80%EB%A6%AC%ED%95%98%EB%8A%94-%EA%B8%B0%EC%A4%80%EA%B3%BC-%EB%B0%A9%EB%B2%95#query-key-factory) 

close #172 
