### PR TITLE
refactor: 리스트 컴포넌트 스크롤 시 그라데이션 효과

### DIFF
--- a/src/app/(main)/gatherings/_component/GatheringCardList.tsx
+++ b/src/app/(main)/gatherings/_component/GatheringCardList.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
-
 import CardList from '@/app/components/CardList/CardList';
+import GradientOverlay from '@/app/components/GradientOverlay/GradientOverlay';
 import { GatheringType } from '@/types/data.type';
 import { useSavedGatheringList } from '@/context/SavedGatheringContext';
-
-import { useInView } from 'react-intersection-observer';
+import useScrollGradientEffect from '@/hooks/useScrollGradientEffect';
 
 interface GatheringCardListProps {
   gatherings: GatheringType[];
@@ -20,36 +18,17 @@ const GatheringCardList = ({ gatherings }: GatheringCardListProps) => {
     updateGathering(id);
   };
 
-  const [topGradientVisible, setTopGradientVisible] = useState(false);
-  const [bottomGradientVisible, setBottomGradientVisible] = useState(false);
-
-  const { ref: firstGatheringRef, inView: firstInView } = useInView({
-    threshold: 0,
-  });
-  const { ref: lastGatheringRef, inView: lastInView } = useInView({
-    threshold: 0,
-  });
-
-  useEffect(() => {
-    setTopGradientVisible(!firstInView);
-    setBottomGradientVisible(!lastInView);
-  }, [firstInView, lastInView]);
+  const {
+    topGradientVisible,
+    bottomGradientVisible,
+    firstItemRef: firstGatheringRef,
+    lastItemRef: lastGatheringRef,
+  } = useScrollGradientEffect();
 
   return (
     <div className='gathering-list mt-24 space-y-24'>
-      {/* Top gradient */}
-      <div
-        className={`fixed left-0 right-0 top-56 z-[30] h-16 bg-gradient-to-b from-white to-transparent p-10 transition-opacity duration-500 ease-in-out md:top-60 dark:from-neutral-900 ${
-          topGradientVisible ? 'opacity-100' : 'opacity-0'
-        }`}
-      />
-
-      {/* Bottom gradient */}
-      <div
-        className={`fixed bottom-0 left-0 right-0 z-[30] h-16 bg-gradient-to-t from-white to-transparent p-10 transition-opacity duration-500 ease-in-out dark:from-neutral-900 ${
-          bottomGradientVisible ? 'opacity-100' : 'opacity-0'
-        }`}
-      />
+      <GradientOverlay position='top' isVisible={topGradientVisible} />
+      <GradientOverlay position='bottom' isVisible={bottomGradientVisible} />
 
       {/* 모임이 없는 경우 */}
       {gatherings.length === 0 ? (

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+import ScrollTopButton from '../components/ScrollTopButton/ScrollTopButton';
+
+const Layout = ({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) => {
+  return (
+    <>
+      {children}
+      <ScrollTopButton />
+    </>
+  );
+};
+
+export default Layout;

--- a/src/app/(main)/mypage/created/_component/GatheringList.tsx
+++ b/src/app/(main)/mypage/created/_component/GatheringList.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import Card from '@/app/components/Card/Card';
-import { GatheringType } from '@/types/data.type';
 import Link from 'next/link';
+import Card from '@/app/components/Card/Card';
+import GradientOverlay from '@/app/components/GradientOverlay/GradientOverlay';
+import useScrollGradientEffect from '@/hooks/useScrollGradientEffect';
+import { GatheringType } from '@/types/data.type';
 
 interface GatheringListProps {
   dataList: GatheringType[];
@@ -20,14 +22,35 @@ const GatheringList = ({ dataList }: GatheringListProps) => {
     throw new Error('잘못된 접근입니다.');
   };
 
+  const {
+    topGradientVisible,
+    bottomGradientVisible,
+    firstItemRef: firstGatheringRef,
+    lastItemRef: lastGatheringRef,
+  } = useScrollGradientEffect();
+
   return (
     <div className='grow'>
-      {updateDataList().map((data) => (
-        <Link key={data.id} href={`/gatherings/${data.id}`}>
-          <Card handleSaveDiscard={handleSaveDiscard} data={data}>
-            <Card.Info />
-          </Card>
-        </Link>
+      <GradientOverlay position='top' isVisible={topGradientVisible} />
+      <GradientOverlay position='bottom' isVisible={bottomGradientVisible} />
+
+      {updateDataList().map((data, index) => (
+        <div
+          key={data.id}
+          ref={
+            index === 0
+              ? firstGatheringRef
+              : index === updateDataList().length - 1
+                ? lastGatheringRef
+                : null
+          }
+        >
+          <Link href={`/gatherings/${data.id}`}>
+            <Card handleSaveDiscard={handleSaveDiscard} data={data}>
+              <Card.Info />
+            </Card>
+          </Link>
+        </div>
       ))}
     </div>
   );

--- a/src/app/(main)/mypage/review/writable/page.tsx
+++ b/src/app/(main)/mypage/review/writable/page.tsx
@@ -9,6 +9,8 @@ import { useState } from 'react';
 import EmptyReviewPage from '../../_component/EmptyReviewPage';
 import ReviewFilterTab from '../../_component/ReviewFilterTab';
 import { queries } from '@/queries';
+import useScrollGradientEffect from '@/hooks/useScrollGradientEffect';
+import GradientOverlay from '@/app/components/GradientOverlay/GradientOverlay';
 
 const WritableReviewsPage = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
@@ -30,24 +32,45 @@ const WritableReviewsPage = () => {
 
   usePreventScroll(isModalOpen);
 
+  const {
+    topGradientVisible,
+    bottomGradientVisible,
+    firstItemRef: firstReviewRef,
+    lastItemRef: lastReviewRef,
+  } = useScrollGradientEffect();
+
   return (
     <>
       <div className='grow pt-16'>
         {/* tab */}
         <ReviewFilterTab />
 
+        <GradientOverlay position='top' isVisible={topGradientVisible} />
+        <GradientOverlay position='bottom' isVisible={bottomGradientVisible} />
+
         {/* cards */}
         {writableReviews?.length ? (
-          writableReviews.map((data) => (
-            <Card key={data.id} data={data}>
-              <Card.Chips />
-              <Card.Info />
-              <Card.Button
-                handleButtonClick={() =>
-                  data.isCompleted && handleOpenModal(data.id)
-                }
-              />
-            </Card>
+          writableReviews.map((data, index) => (
+            <div
+              key={data.id}
+              ref={
+                index === 0
+                  ? firstReviewRef
+                  : index === writableReviews.length - 1
+                    ? lastReviewRef
+                    : null
+              }
+            >
+              <Card data={data}>
+                <Card.Chips />
+                <Card.Info />
+                <Card.Button
+                  handleButtonClick={() =>
+                    data.isCompleted && handleOpenModal(data.id)
+                  }
+                />
+              </Card>
+            </div>
           ))
         ) : (
           <EmptyReviewPage />

--- a/src/app/(main)/mypage/review/written/_component/ReviewsList.tsx
+++ b/src/app/(main)/mypage/review/written/_component/ReviewsList.tsx
@@ -6,11 +6,7 @@ import Review from '@/app/components/Review/Review';
 import useScrollGradientEffect from '@/hooks/useScrollGradientEffect';
 import { ReviewsType } from '@/types/data.type';
 
-const WrittenReviews = ({
-  writtenReviews,
-}: {
-  writtenReviews: ReviewsType[];
-}) => {
+const ReviewsList = ({ writtenReviews }: { writtenReviews: ReviewsType[] }) => {
   const {
     topGradientVisible,
     bottomGradientVisible,
@@ -50,4 +46,4 @@ const WrittenReviews = ({
   );
 };
 
-export default WrittenReviews;
+export default ReviewsList;

--- a/src/app/(main)/mypage/review/written/_component/WrittenReviews.tsx
+++ b/src/app/(main)/mypage/review/written/_component/WrittenReviews.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Link from 'next/link';
+import GradientOverlay from '@/app/components/GradientOverlay/GradientOverlay';
+import Review from '@/app/components/Review/Review';
+import useScrollGradientEffect from '@/hooks/useScrollGradientEffect';
+import { ReviewsType } from '@/types/data.type';
+
+const WrittenReviews = ({
+  writtenReviews,
+}: {
+  writtenReviews: ReviewsType[];
+}) => {
+  const {
+    topGradientVisible,
+    bottomGradientVisible,
+    firstItemRef: firstReviewRef,
+    lastItemRef: lastReviewRef,
+  } = useScrollGradientEffect();
+
+  return (
+    <div className='my-24 flex flex-col gap-24'>
+      <GradientOverlay position='top' isVisible={topGradientVisible} />
+      <GradientOverlay position='bottom' isVisible={bottomGradientVisible} />
+
+      {writtenReviews.map((review, index) => (
+        <div
+          key={review.id}
+          ref={
+            index === 0
+              ? firstReviewRef
+              : index === writtenReviews.length - 1
+                ? lastReviewRef
+                : null
+          }
+        >
+          <Link href={`/gatherings/${review.Gathering.id}`}>
+            <Review
+              key={review.id}
+              rating={review.score}
+              image_source={review.Gathering.image}
+              description={review.comment}
+              user_name={review.User.name}
+              date={review.createdAt}
+            />
+          </Link>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default WrittenReviews;

--- a/src/app/(main)/mypage/review/written/page.tsx
+++ b/src/app/(main)/mypage/review/written/page.tsx
@@ -1,10 +1,9 @@
 import { getUserData } from '@/app/api/actions/mypage/getUserData';
 import getReviewList from '@/app/api/actions/reviews/getReviewList';
-import Review from '@/app/components/Review/Review';
-import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import EmptyReviewPage from '../../_component/EmptyReviewPage';
 import ReviewFilterTab from '../../_component/ReviewFilterTab';
+import WrittenReviews from './_component/WrittenReviews';
 
 const WrittenReviewsPage = async () => {
   const user = await getUserData();
@@ -26,20 +25,7 @@ const WrittenReviewsPage = async () => {
 
       {/* cards */}
       {writtenReviews?.length ? (
-        <div className='my-24 flex flex-col gap-24'>
-          {writtenReviews.map((review) => (
-            <Link href={`/gatherings/${review.Gathering.id}`} key={review.id}>
-              <Review
-                key={review.id}
-                rating={review.score}
-                image_source={review.Gathering.image}
-                description={review.comment}
-                user_name={review.User.name}
-                date={review.createdAt}
-              />
-            </Link>
-          ))}
-        </div>
+        <WrittenReviews writtenReviews={writtenReviews} />
       ) : (
         <EmptyReviewPage />
       )}

--- a/src/app/(main)/mypage/review/written/page.tsx
+++ b/src/app/(main)/mypage/review/written/page.tsx
@@ -3,7 +3,7 @@ import getReviewList from '@/app/api/actions/reviews/getReviewList';
 import { redirect } from 'next/navigation';
 import EmptyReviewPage from '../../_component/EmptyReviewPage';
 import ReviewFilterTab from '../../_component/ReviewFilterTab';
-import WrittenReviews from './_component/WrittenReviews';
+import ReviewsList from './_component/ReviewsList';
 
 const WrittenReviewsPage = async () => {
   const user = await getUserData();
@@ -25,7 +25,7 @@ const WrittenReviewsPage = async () => {
 
       {/* cards */}
       {writtenReviews?.length ? (
-        <WrittenReviews writtenReviews={writtenReviews} />
+        <ReviewsList writtenReviews={writtenReviews} />
       ) : (
         <EmptyReviewPage />
       )}

--- a/src/app/(main)/reviews/_components/ReviewList.tsx
+++ b/src/app/(main)/reviews/_components/ReviewList.tsx
@@ -1,9 +1,11 @@
-import Review from '@/app/components/Review/Review';
-import { ReviewsType } from '@/types/data.type';
-import Loader from '@/app/components/Loader/Loader';
 import { useEffect } from 'react';
-import { useInView } from 'react-intersection-observer';
 import Link from 'next/link';
+import { useInView } from 'react-intersection-observer';
+import Review from '@/app/components/Review/Review';
+import Loader from '@/app/components/Loader/Loader';
+import GradientOverlay from '@/app/components/GradientOverlay/GradientOverlay';
+import { ReviewsType } from '@/types/data.type';
+import useScrollGradientEffect from '@/hooks/useScrollGradientEffect';
 
 interface ReviewListProps {
   reviewList: ReviewsType[][];
@@ -27,25 +29,42 @@ const ReviewList = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inView, hasMore]);
 
+  const {
+    topGradientVisible,
+    bottomGradientVisible,
+    firstItemRef: firstReviewRef,
+    lastItemRef: lastReviewRef,
+  } = useScrollGradientEffect();
+
   return (
     <div className='mt-24 space-y-12'>
+      <GradientOverlay position='top' isVisible={topGradientVisible} />
+      <GradientOverlay position='bottom' isVisible={bottomGradientVisible} />
+
       {reviewList.flatMap((list) =>
         list.map((item, index) => (
-          <Link
-            href={`/gatherings/${item.Gathering.id}`}
+          <div
             key={item.id}
-            className='block'
+            ref={
+              index === 0
+                ? firstReviewRef
+                : index === reviewList.length - 1
+                  ? lastReviewRef
+                  : null
+            }
           >
-            <Review
-              image_source={item.Gathering.image}
-              rating={item.score}
-              description={item.comment}
-              place={item.Gathering.name}
-              location={item.Gathering.location}
-              user_name={item.User.name}
-              date={item.createdAt}
-            />
-          </Link>
+            <Link href={`/gatherings/${item.Gathering.id}`} className='block'>
+              <Review
+                image_source={item.Gathering.image}
+                rating={item.score}
+                description={item.comment}
+                place={item.Gathering.name}
+                location={item.Gathering.location}
+                user_name={item.User.name}
+                date={item.createdAt}
+              />
+            </Link>
+          </div>
         )),
       )}
 

--- a/src/app/(main)/saved/_component/SavedList.tsx
+++ b/src/app/(main)/saved/_component/SavedList.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import CardList from '@/app/components/CardList/CardList';
-import { useSavedGatheringList } from '@/context/SavedGatheringContext';
-import { GatheringType } from '@/types/data.type';
 import Link from 'next/link';
+import CardList from '@/app/components/CardList/CardList';
+import GradientOverlay from '@/app/components/GradientOverlay/GradientOverlay';
+import { useSavedGatheringList } from '@/context/SavedGatheringContext';
+import useScrollGradientEffect from '@/hooks/useScrollGradientEffect';
+import { GatheringType } from '@/types/data.type';
 
 interface SavedListProps {
   dataList: GatheringType[];
@@ -18,16 +20,37 @@ const SavedList = ({ dataList }: SavedListProps) => {
     updateGathering(id);
   };
 
+  const {
+    topGradientVisible,
+    bottomGradientVisible,
+    firstItemRef: firstGatheringRef,
+    lastItemRef: lastGatheringRef,
+  } = useScrollGradientEffect();
+
   return (
     <>
-      {dataList.map((item) => (
-        <Link href={`/gatherings/${item.id}`} key={item.id}>
-          <CardList
-            data={item}
-            isSaved={isSaved(item.id)}
-            handleButtonClick={handleButtonClick}
-          />
-        </Link>
+      <GradientOverlay position='top' isVisible={topGradientVisible} />
+      <GradientOverlay position='bottom' isVisible={bottomGradientVisible} />
+
+      {dataList.map((item, index) => (
+        <div
+          key={item.id}
+          ref={
+            index === 0
+              ? firstGatheringRef
+              : index === dataList.length - 1
+                ? lastGatheringRef
+                : null
+          }
+        >
+          <Link href={`/gatherings/${item.id}`} key={item.id}>
+            <CardList
+              data={item}
+              isSaved={isSaved(item.id)}
+              handleButtonClick={handleButtonClick}
+            />
+          </Link>
+        </div>
       ))}
     </>
   );

--- a/src/app/components/CardList/CardList.test.tsx
+++ b/src/app/components/CardList/CardList.test.tsx
@@ -99,11 +99,17 @@ describe('Tag Component Render', () => {
 
 // SAVED 아이콘 클릭으로 토글 테스트
 describe('Saved button Test', () => {
+  // dateTime을 내일 날짜로 변경 (마감되지 않은 챌린지)
+  const date = new Date();
+  date.setDate(date.getDate() + 1);
+  const MOCK_DATA = { ...MOCK_DATA_BASE, dateTime: date.toISOString() };
+
   it('should toggle isSaved state when handleToggleSave is called', () => {
     const handleToggleSave = jest.fn();
+
     render(
       <CardList
-        data={MOCK_DATA_BASE}
+        data={MOCK_DATA}
         isSaved={false}
         handleButtonClick={handleToggleSave}
       />,
@@ -138,9 +144,7 @@ describe('Saved button Test', () => {
   // 아이콘 클릭 시 이벤트 핸들러 작동 여부 테스트
   it('should call handleToggleSave when IconSaveInactive is clicked', () => {
     const handleToggleSave = jest.fn();
-    render(
-      <CardList data={MOCK_DATA_BASE} handleButtonClick={handleToggleSave} />,
-    );
+    render(<CardList data={MOCK_DATA} handleButtonClick={handleToggleSave} />);
 
     const inactiveButton = screen.getByTestId('IconSaveInactive');
     fireEvent.click(inactiveButton);

--- a/src/app/components/GradientOverlay/GradientOverlay.tsx
+++ b/src/app/components/GradientOverlay/GradientOverlay.tsx
@@ -1,0 +1,26 @@
+interface GradientOverlayProps {
+  position: 'top' | 'bottom';
+  isVisible: boolean;
+}
+
+const GradientOverlay = ({ position, isVisible }: GradientOverlayProps) => {
+  const positionClasses = () => {
+    if (position === 'top') {
+      return 'top-56 bg-gradient-to-b  md:top-60 ';
+    }
+    if (position === 'bottom') {
+      return 'bottom-0  bg-gradient-to-t';
+    }
+    return null;
+  };
+
+  const gradientClasses = `fixed left-0 right-0 z-[30] h-16 from-white to-transparent p-10 transition-opacity duration-500 ease-in-out dark:from-neutral-900`;
+
+  return (
+    <div
+      className={`${gradientClasses} ${positionClasses()} ${isVisible ? 'opacity-100' : 'opacity-0'}`}
+    />
+  );
+};
+
+export default GradientOverlay;

--- a/src/app/components/GradientOverlay/GradientOverlay.tsx
+++ b/src/app/components/GradientOverlay/GradientOverlay.tsx
@@ -14,7 +14,7 @@ const GradientOverlay = ({ position, isVisible }: GradientOverlayProps) => {
     return null;
   };
 
-  const gradientClasses = `fixed left-0 right-0 z-[30] h-16 from-white to-transparent p-10 transition-opacity duration-500 ease-in-out dark:from-neutral-900`;
+  const gradientClasses = `fixed left-0 right-0 z-gradient h-16 from-white to-transparent p-10 transition-opacity duration-500 ease-in-out dark:from-neutral-900`;
 
   return (
     <div

--- a/src/app/components/ScrollTopButton/ScrollTopButton.tsx
+++ b/src/app/components/ScrollTopButton/ScrollTopButton.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { FaAngleUp } from 'react-icons/fa6';
+
+const ScrollTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // 스크롤 위치 감지
+  const handleScroll = () => {
+    const scrollHeight = window.scrollY;
+    setIsVisible(scrollHeight > 1000); // 스크롤이 1000 이상일 때만 버튼 표시
+  };
+
+  // 페이지가 로드될 때 스크롤 이벤트를 설정
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  // 버튼 클릭 시 상단으로 스크롤
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <button
+      type='button'
+      aria-label='Scroll to top'
+      onClick={scrollToTop}
+      className={`z-scrollButton fixed bottom-20 right-16 flex h-48 w-48 items-center justify-center rounded-full bg-var-orange-500 text-white shadow-md ${isVisible ? 'opacity-100' : 'opacity-0'} transition-opacity duration-300 ease-in-out dark:bg-var-orange-700`}
+    >
+      <FaAngleUp className='h-24 w-24' />
+    </button>
+  );
+};
+
+export default ScrollTopButton;

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -42,12 +42,12 @@ export default function Providers({ children }: { children: ReactNode }) {
   // QueryClientProvider로 자식 컴포넌트들을 감싸서 QueryClient를 제공
   return (
     <ThemeProvider attribute='class' defaultTheme='system'>
-        <SavedGatheringProvider>
-          <QueryClientProvider client={queryClient}>
-            {children}
-            <ReactQueryDevtools initialIsOpen={false} />
-          </QueryClientProvider>
-        </SavedGatheringProvider>
+      <SavedGatheringProvider>
+        <QueryClientProvider client={queryClient}>
+          {children}
+          <ReactQueryDevtools initialIsOpen={false} />
+        </QueryClientProvider>
+      </SavedGatheringProvider>
     </ThemeProvider>
   );
 }

--- a/src/hooks/useScrollGradientEffect.ts
+++ b/src/hooks/useScrollGradientEffect.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+const useScrollGradientEffect = () => {
+  const [topGradientVisible, setTopGradientVisible] = useState(false);
+  const [bottomGradientVisible, setBottomGradientVisible] = useState(false);
+
+  const { ref: firstItemRef, inView: firstInView } = useInView({
+    threshold: 0,
+  });
+  const { ref: lastItemRef, inView: lastInView } = useInView({
+    threshold: 0,
+  });
+
+  useEffect(() => {
+    setTopGradientVisible(!firstInView);
+    setBottomGradientVisible(!lastInView);
+  }, [firstInView, lastInView]);
+
+  return {
+    topGradientVisible,
+    bottomGradientVisible,
+    firstItemRef,
+    lastItemRef,
+  };
+};
+
+export default useScrollGradientEffect;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,6 +27,8 @@ const config: Config = {
       base: '1',
       nav: '2',
       dropdown: '10',
+      gradient: '30',
+      scrollButton: '40',
       popup: '999',
       floating: '1000',
     },


### PR DESCRIPTION
## ✏️ 작업 내용

#### 전체 페이지의 데이터 리스트 영역에 스크롤 시 그라디언트 애니메이션 효과를 넣기 위해, 기존 코드를 활용하던 중 아래와 같이 작업하였습니다.

- 그라데이션 영역 div 를 공통 컴포넌트로 분리
- 스크롤 시 그라데이션 효과를 커스텀 훅으로 분리
- 전체 리스트 페이지에 커스텀 훅 적용
  - 마이페이지 / 나의리뷰 / 작성한 리뷰 `mypage/review/written`  : 해당 page 컴포넌트가 서버 컴포넌트인 관계로, 커스텀 훅을 사용하기 위해 리스트 컴포넌트로 분리, 그라데이션 효과를 추가하였습니다.


#### 상단으로 스크롤 하기 버튼을 추가했습니다.
- (auth) 그룹을 제외, (main) 페이지 layout에 버튼을 추가했습니다.
- z-index를 리스트의 그라데이션 영역보다 높게 / 바텀 플로팅, 팝업 등보다 낮게 잡기 위해 tailwind.config 에 속성을 추가하였습니다.
- 스크롤 위치가 일정 이상일 때만 버튼이 보이고, 사라집니다.
- dev 모드로 접속 시 rq devtool 버튼에 가려져서 안 보입니다. 아래 스크린샷 참고해 주세요.

## 📷 스크린샷

https://github.com/user-attachments/assets/39ce201b-255d-4ac1-98b0-3db7d3a850c0

![image](https://github.com/user-attachments/assets/1ecfec10-d8be-4d46-8d5f-fe3b2c990be2)

## ✍️ 사용법

## 🎸 기타

close #154 