### PR TITLE
fix: 모임 상세페이지 날짜 표시 형식 변경

### DIFF
--- a/src/app/(main)/gatherings/[id]/_component/GatheringImage.tsx
+++ b/src/app/(main)/gatherings/[id]/_component/GatheringImage.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react';
 
 interface GatheringImageProps {
   image: string;
-  endTime?: string;
+  endTime: string;
 }
 
 const GatheringImage = ({ image, endTime }: GatheringImageProps) => {

--- a/src/utils/getTagMessage.ts
+++ b/src/utils/getTagMessage.ts
@@ -1,10 +1,12 @@
-const getTagMessage = (daysLeft: number | null, endTime?: string) => {
+import { formatTimeHours } from './formatDate';
+
+const getTagMessage = (daysLeft: number | null, endTime: string) => {
   if (daysLeft === null) return '';
 
   if (daysLeft < 0) {
     return '마감된 모임입니다.';
   } else if (daysLeft === 0) {
-    return `오늘 ${endTime}시 마감`;
+    return `오늘 ${formatTimeHours(endTime)}시 마감`;
   } else {
     return `${daysLeft}일 후 마감`;
   }


### PR DESCRIPTION
## ✏️ 작업 내용

- 모임 상세페이지 날짜 표시 형식 변경

## 📷 스크린샷

### 이전

![image](https://github.com/user-attachments/assets/f88183b5-516c-479a-9d21-e7df43bcc660)

### 이후

<img width="1016" alt="스크린샷 2024-10-16 16 06 07" src="https://github.com/user-attachments/assets/8c3db64d-2cbe-49a4-a260-9d81ebd1eb8b">

## ✍️ 사용법

## 🎸 기타

시간 표시하는 함수만 하나 추가한거라 금방 봐 주실 수 있을 것 같습니다!
확인 후 피드백 부탁드립니다!