### PR TITLE
fix: /gatherings 필터링 관련 버그 수정

### DIFF
--- a/src/app/components/Filter/Filter.tsx
+++ b/src/app/components/Filter/Filter.tsx
@@ -53,7 +53,7 @@ const FilterSort = ({
     data-testid='filter-component'
   >
     <IconSort className='${iconClass} h-24 w-24' />
-    <span className='hidden md:mr-8 md:inline'>{text}</span>
+    <span className='hidden whitespace-nowrap md:mr-8 md:inline'>{text}</span>
   </div>
 );
 

--- a/src/app/components/Filter/FilterDate.tsx
+++ b/src/app/components/Filter/FilterDate.tsx
@@ -83,7 +83,7 @@ const FilterDate = ({
         <CalendarModal
           initialSelectedData={selectedDate}
           handleClickButtons={handleClickButtons}
-          CalendarProps={{ changeEndDays: 0 }}
+          CalendarProps={{ changeEndDays: undefined }}
           onCloseModal={() => setIsOpen(false)}
         />
       </div>


### PR DESCRIPTION
## ✏️ 작업 내용

- 날짜로 필터링 시 오늘 이후의 날짜를 설정할 수 없었던 버그 수정
- 필터링 시 '참여 인원 순' 글자가 깨지는 버그 수정

## 📷 스크린샷

### 날짜 필터링

<img width="336" alt="스크린샷 2024-10-16 18 23 30" src="https://github.com/user-attachments/assets/d6913ba7-d195-4402-98d5-b0d533c17068">

### 참여 인원 순

<img width="187" alt="스크린샷 2024-10-16 18 23 07" src="https://github.com/user-attachments/assets/955df4c9-7869-485b-9985-db59ffa45494">

## ✍️ 사용법

## 🎸 기타

확인 후 피드백 부탁드립니다!