### PR TITLE
fix: 주최자일 때 예약취소 버튼 비활성화 및 모임취소 시 재확인 모달 추가

### DIFF
--- a/src/app/(main)/mypage/_component/MyGatheringList.tsx
+++ b/src/app/(main)/mypage/_component/MyGatheringList.tsx
@@ -38,31 +38,35 @@ const MyGatheringList = ({ initData, user }: MyGatheringListProps) => {
         queryFn={getMyGatherings}
         emptyText='아직 참여한 모임이 없습니다.'
         errorText='모임을 불러오지 못했습니다.'
-        renderItem={(item) => (
-          <Card data={item}>
-            <Card.Chips />
-            <Card.Info />
-            {item.createdBy !== user?.id ? (
-              // 참가자일 때 렌더링
-              <Card.Button
-                handleButtonClick={() => {
-                  item.isCompleted
-                    ? handleOpenModal(item.id)
-                    : handleWithdrawClickWithId(item.id, queries.joined._def);
-                }}
-              />
-            ) : (
-              // 주최자일 때 렌더링
-              item.isCompleted && (
+        renderItem={(item) => {
+          // 주최자인지 여부를 확인하는 변수
+          const isHost = item.createdBy === user?.id;
+          return (
+            <Card data={item}>
+              <Card.Chips />
+              <Card.Info />
+              {isHost ? (
+                // 주최자일 때 렌더링
+                item.isCompleted && (
+                  <Card.Button
+                    handleButtonClick={() => {
+                      handleOpenModal(item.id);
+                    }}
+                  />
+                )
+              ) : (
+                // 참가자일 때 렌더링
                 <Card.Button
                   handleButtonClick={() => {
-                    handleOpenModal(item.id);
+                    item.isCompleted
+                      ? handleOpenModal(item.id)
+                      : handleWithdrawClickWithId(item.id, queries.joined._def);
                   }}
                 />
-              )
-            )}
-          </Card>
-        )}
+              )}
+            </Card>
+          );
+        }}
       />
       {isModalOpen && (
         <ReviewModal gatheringId={cardId} onClose={handleCloseModal} />

--- a/src/app/(main)/mypage/_component/MyGatheringList.tsx
+++ b/src/app/(main)/mypage/_component/MyGatheringList.tsx
@@ -42,13 +42,25 @@ const MyGatheringList = ({ initData, user }: MyGatheringListProps) => {
           <Card data={item}>
             <Card.Chips />
             <Card.Info />
-            <Card.Button
-              handleButtonClick={() => {
-                item.isCompleted
-                  ? handleOpenModal(item.id)
-                  : handleWithdrawClickWithId(item.id, queries.joined._def);
-              }}
-            />
+            {item.createdBy !== user?.id ? (
+              // 참가자일 때 렌더링
+              <Card.Button
+                handleButtonClick={() => {
+                  item.isCompleted
+                    ? handleOpenModal(item.id)
+                    : handleWithdrawClickWithId(item.id, queries.joined._def);
+                }}
+              />
+            ) : (
+              // 주최자일 때 렌더링
+              item.isCompleted && (
+                <Card.Button
+                  handleButtonClick={() => {
+                    handleOpenModal(item.id);
+                  }}
+                />
+              )
+            )}
           </Card>
         )}
       />

--- a/src/app/components/BottomFloatingBar/ParticipationButton.tsx
+++ b/src/app/components/BottomFloatingBar/ParticipationButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 
 import { UserData } from '@/types/client.type';
@@ -10,6 +10,7 @@ import useCancelGathering from '@/hooks/useCancelGathering';
 import useParticipation from '@/hooks/useParticipation';
 import { GatheringParticipantsType } from '@/types/data.type';
 import Popup from '../Popup/Popup';
+import CancelGatheringModal from '../Modal/CancelGatheringModal';
 
 interface ParticipationButtonProps {
   isHost: boolean;
@@ -31,6 +32,7 @@ const ParticipationButton = ({
   participantsData,
 }: ParticipationButtonProps) => {
   const router = useRouter();
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const params = useParams();
 
   const { copyUrlToClipboard } = useCopyUrlToClipboard();
@@ -90,10 +92,18 @@ const ParticipationButton = ({
     const disabled = isRegistrationEnded; // 마감일이 지난 경우 버튼 비활성화
 
     return (
-      <div className='flex w-[330px] gap-[10px]'>
-        {renderButton('취소하기', 'white', cancelGathering)}
-        {renderButton('공유하기', 'default', copyUrlToClipboard, disabled)}
-      </div>
+      <>
+        <div className='flex w-[330px] gap-[10px]'>
+          {renderButton('취소하기', 'white', () => setIsModalOpen(true))}
+          {renderButton('공유하기', 'default', copyUrlToClipboard, disabled)}
+        </div>
+        {isModalOpen && (
+          <CancelGatheringModal
+            onClick={cancelGathering}
+            onClose={() => setIsModalOpen(false)}
+          />
+        )}
+      </>
     );
   }
 

--- a/src/app/components/Modal/CancelGatheringModal.tsx
+++ b/src/app/components/Modal/CancelGatheringModal.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import Button from '../Button/Button';
+import ModalFrame from './ModalFrame';
+import ModalHeader from './ModalHeader';
+
+interface CancelGatheringModalProps {
+  onClose: () => void;
+  onSubmit?: () => void;
+}
+
+const CancelGatheringModal = ({
+  onClose,
+  onSubmit,
+}: CancelGatheringModalProps) => {
+  return (
+    <ModalFrame onClose={onClose}>
+      <div className='flex max-h-328 w-320 flex-col gap-24 rounded-xl bg-var-white p-24 md:w-440 dark:border dark:border-neutral-600 dark:bg-neutral-800'>
+        <ModalHeader title={''} onClose={onClose} />
+        <div className='text-center text-16 font-medium'>
+          모임을 정말 취소하시겠습니까?
+        </div>
+        <div className='flex items-center gap-16'>
+          {/* 버튼 그룹 */}
+          <div className={'flex w-full justify-center gap-8'}>
+            <div className='w-120'>
+              <Button
+                name='취소'
+                variant='white'
+                onClick={() => console.log('모임취소')}
+              />
+            </div>
+            <div className='w-120'>
+              <Button
+                name='확인'
+                variant='default'
+                onClick={() => console.log('닫기')}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </ModalFrame>
+  );
+};
+
+export default CancelGatheringModal;

--- a/src/app/components/Modal/CancelGatheringModal.tsx
+++ b/src/app/components/Modal/CancelGatheringModal.tsx
@@ -13,7 +13,6 @@ const CancelGatheringModal = ({
   onClose,
   onClick,
 }: CancelGatheringModalProps) => {
-  console.log('모달');
   return (
     <ModalFrame onClose={onClose}>
       <div className='flex max-h-328 w-320 flex-col gap-24 rounded-xl bg-var-white p-24 md:w-440 dark:border dark:border-neutral-600 dark:bg-neutral-800'>

--- a/src/app/components/Modal/CancelGatheringModal.tsx
+++ b/src/app/components/Modal/CancelGatheringModal.tsx
@@ -6,13 +6,14 @@ import ModalHeader from './ModalHeader';
 
 interface CancelGatheringModalProps {
   onClose: () => void;
-  onSubmit?: () => void;
+  onClick?: () => void;
 }
 
 const CancelGatheringModal = ({
   onClose,
-  onSubmit,
+  onClick,
 }: CancelGatheringModalProps) => {
+  console.log('모달');
   return (
     <ModalFrame onClose={onClose}>
       <div className='flex max-h-328 w-320 flex-col gap-24 rounded-xl bg-var-white p-24 md:w-440 dark:border dark:border-neutral-600 dark:bg-neutral-800'>
@@ -24,18 +25,10 @@ const CancelGatheringModal = ({
           {/* 버튼 그룹 */}
           <div className={'flex w-full justify-center gap-8'}>
             <div className='w-120'>
-              <Button
-                name='취소'
-                variant='white'
-                onClick={() => console.log('모임취소')}
-              />
+              <Button name='취소' variant='white' onClick={onClose} />
             </div>
             <div className='w-120'>
-              <Button
-                name='확인'
-                variant='default'
-                onClick={() => console.log('닫기')}
-              />
+              <Button name='확인' variant='default' onClick={onClick} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## ✏️ 작업 내용

- 주최자일 때 예약취소 버튼 비활성화
- 모임취소 시 재확인 모달 추가

## 📷 스크린샷

### 주최자일 때 예약취소 버튼 비활성화
<img width="863" alt="스크린샷 2024-10-17 오후 2 01 30" src="https://github.com/user-attachments/assets/2a89708a-f25a-41aa-bbc6-5887b00c43df">

### 모임취소 시 재확인 모달
<img width="1265" alt="스크린샷 2024-10-17 오후 1 50 01" src="https://github.com/user-attachments/assets/374a1f7b-8b9f-4bba-9724-174bc0699d5d">

close #211