### PR TITLE
test: 모든 리뷰 페이지 e2e 테스트코드 작성

### DIFF
--- a/src/__TEST__/reviews/page.test.tsx
+++ b/src/__TEST__/reviews/page.test.tsx
@@ -1,56 +1,59 @@
 import { test, expect } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/reviews');
-  // 네트워크 활동이 없을 때까지 기다림 (데이터 로딩 포함)
-  await page.waitForLoadState('networkidle');
+  await page.goto('/reviews', { waitUntil: 'networkidle' });
+
+  test.slow();
 });
 
 // 페이지 정상 로드 확인
 test('render title, score and reviews', async ({ page }) => {
   // Head 타이틀 확인
-  await expect(page.locator('h2')).toContainText('모든 리뷰');
+  await expect(page.getByRole('heading', { name: '모든 리뷰' })).toBeVisible();
 
   // Score 데이터가 최초 3.7인지 확인
-  expect(page.getByTestId('average-score')).toHaveText('3.7');
+  await expect(page.getByTestId('average-score')).toHaveText('3.7');
 
   // 최초 리뷰 데이터가 10개인지 확인 (서버사이드로 렌더링 된 데이터)
-  expect(page.getByTestId('review-item')).toHaveCount(10);
+  await expect(page.getByTestId('review-item')).toHaveCount(10);
 });
 
 test.describe('change score data when clicked tab or chip', () => {
   test('average score is 5 When clicked WORKATION tab ', async ({ page }) => {
-    await page.click('[data-testid="tab-WORKATION"]');
-    const workationScore = page.getByTestId('average-score');
-    await workationScore.waitFor();
-    expect(workationScore).toHaveText('5');
+    await page.getByTestId('tab-WORKATION').click();
+
+    const score = page.getByTestId('average-score');
+    await score.waitFor();
+    await expect(score).toHaveText('5');
   });
 
   test('average score is 3.7 When clicked DALLAEMFIT tab ', async ({
     page,
   }) => {
-    await page.click('[data-testid="tab-DALLAEMFIT"]');
-    const dallaemfitScore = page.getByTestId('average-score');
-    await dallaemfitScore.waitFor();
-    expect(dallaemfitScore).toHaveText('3.7');
+    await page.getByTestId('tab-DALLAEMFIT').click();
+
+    const score = page.getByTestId('average-score');
+    await score.waitFor();
+    await expect(score).toHaveText('3.7');
   });
 
   test('average score is 3.5 When clicked OFFICE STRETCHING chip ', async ({
     page,
   }) => {
     await page.locator('span').getByText('오피스 스트레칭').click();
-    const officeStretchingScore = page.getByTestId('average-score');
-    await officeStretchingScore.waitFor();
-    expect(officeStretchingScore).toHaveText('3.5');
+
+    const score = page.getByTestId('average-score');
+    await score.waitFor();
+    await expect(score).toHaveText('3.5');
   });
 
   test('average score is 5 When clicked MINDFULNESS chip ', async ({
     page,
   }) => {
     await page.locator('span').getByText('마인드풀니스').click();
-    const mindfulnessScore = page.getByTestId('average-score');
-    await mindfulnessScore.waitFor();
-    expect(mindfulnessScore).toHaveText('5');
+    const score = page.getByTestId('average-score');
+    await score.waitFor();
+    await expect(score).toHaveText('5');
   });
 });
 
@@ -60,7 +63,7 @@ test('filter reviews by location', async ({ page }) => {
   // 건대입구 필터링 시 리뷰 아이템이 10개인지 확인
   await page.getByTestId('filter-component').getByText('지역 전체').click();
   const filterOptions1 = page.locator('span').getByText('건대입구');
-  await filterOptions1.waitFor();
+  await filterOptions1.waitFor({ state: 'visible' });
   await filterOptions1.click();
 
   expect(page.getByTestId('review-item')).toHaveCount(10);
@@ -68,23 +71,27 @@ test('filter reviews by location', async ({ page }) => {
   // 신림 필터링 시 리뷰 아이템이 0개인지 확인
   await page.getByTestId('filter-component').getByText('건대입구').click();
   const filterOptions2 = page.locator('span').getByText('신림');
-  await filterOptions2.waitFor();
+  await filterOptions2.waitFor({ state: 'visible' });
   await filterOptions2.click();
 
-  expect(page.getByTestId('review-item')).toHaveCount(0);
+  await expect(page.getByText('아직 리뷰가 없어요')).toBeVisible();
+  const count = await page.getByTestId('review-item').count();
+  expect(count).toBe(0);
 });
 
 // 무한스크롤 테스트
 test('infinite scroll', async ({ page }) => {
   // 리뷰 아이템이 10개인지 확인
-  expect(page.getByTestId('review-item')).toHaveCount(10);
+  await expect(page.getByTestId('review-item')).toHaveCount(10);
 
   // 스크롤 이벤트
   await page.getByTestId('hasMoreRef').scrollIntoViewIfNeeded();
 
   // 추가로 10개의 리뷰 아이템이 렌더링 되었는지 확인
-  await page.waitForSelector('[data-testid="review-item"]:nth-child(20)');
-  expect(page.getByTestId('review-item')).toHaveCount(20);
+  const item20th = page.getByTestId('review-item').nth(19);
+  await item20th.waitFor({ state: 'visible' });
+
+  await expect(page.getByTestId('review-item')).toHaveCount(20);
 });
 
 // 리뷰 아이템 클릭 시 상세 페이지로 이동 확인

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -4,6 +4,8 @@ export async function register() {
     process.env.NEXT_RUNTIME === 'nodejs'
   ) {
     const { server } = await import('./msw/server');
-    server.listen();
+    server.listen({
+      onUnhandledRequest: 'bypass',
+    });
   }
 }

--- a/src/msw/handlers.ts
+++ b/src/msw/handlers.ts
@@ -22,10 +22,10 @@ export const handlers = [
 
   /*
    * GET
-   * /reviews/score
+   * /reviews/scores
    */
   http.get(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/reviews/score`,
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/reviews/scores`,
     ({ request }) => {
       const url = new URL(request.url);
       const queryParam = qs.parse(url.searchParams.toString());


### PR DESCRIPTION
## ✏️ 작업 내용

#### 페이지 로드 시 정보 확인
- [x] `<h2>모든 리뷰</h2>` 가 존재하는지 확인  
- [x] Score 데이터가 3.7인지 확인 (모킹된 데이터)
- [x] 최초 리뷰 데이터가 10개인지 확인 (서버사이드로 렌더링 된 데이터)

#### tab, chip 클릭 시 Score 데이터 변경 확인 (모킹된 데이터)
- [x] [워케이션] 탭 클릭 시 score가 5 인지 확인
- [x] [달램핏] 탭 클릭 시 score가 3.7 인지 확인
- [x] [오피스 스트레칭] 칩 클릭 시 score가 3.5 인지 확인
- [x] [마인드풀니스] 칩 클릭 시 score가 5 인지 확인

#### 지역 필터링 확인 (목데이터는 전부 건대입구 이기 때문에, 건대입구 필터링 시 10개, 다른 아이템은 0개가 되어야 함)
- [x] [지역] 필터링 클릭 후 [건대입구] 선택 시, 리뷰 데이터가 10개인지 확인
- [x] [지역] 필터링 클릭 후 [신림] 선택 시, 리뷰 데이터가 0개인지 확인

#### 무한스크롤 테스트
- [x] 최초 리뷰 데이터가 10개인지 확인 (서버사이드로 렌더링 된 데이터)
- [x] 스크롤을 가장 아래로 내린 후 (hasMoreRef 를 찾음) 20번째 리뷰 데이터가 나타날 때까지 기다림
- [x] 총 리뷰 데이터가 20개인지 확인

#### 리뷰 아이템 클릭 시 
- [x] 첫번째 아이템 클릭 시 (목데이터 상 id가 1) 상세페이지로 이동하는지 확인 (url 확인)

## 📷 스크린샷

## ✍️ 사용법

### 꿀팁 ! Codegen 사용하기

2개의 터미널을 열어 각각 `npx playwright codegen` , `npm run dev:test` 를 실행합니다.
(`dev:test` 스크립트로 msw 환경을 실행, codegen 브라우저로 이를 확인)

![image](https://github.com/user-attachments/assets/ba48b966-4b0d-4d5c-b332-24fe4d9f1e36)

playwright 로 테스트 작성 시 locator(선택자) 가 명확한 것이 중요합니다.
codegen을 통하여 원하는 요소의 선택자를 찾아내거나, 내가 쓴 선택자가 원하는대로 요소를 바라보는지 검증할 수 있습니다.

## 🎸 기타

playwright 에서 어떤 expect 시에 사용되는 메소드 (Assertions) 는 자동으로 재시도 하는 것과 재시도를 하지 않는 것이 있습니다.
자동으로 재시도 하는 Assertions은 테스트가 통과하거나, 타임아웃 될 때까지 계속해서 재시도하며, 비동기적이므로 `await` 을 사용합니다. Assertions의 종류는 [공식문서](https://playwright.dev/docs/test-assertions) 를 참고하세요. 


close #181 